### PR TITLE
fix(gcm): ensure tag vector has 16 bytes

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -702,6 +702,7 @@ std::vector<unsigned char> AES::EncryptGCM (
         std::vector<unsigned char> iv,
         std::vector<unsigned char> aad,
         std::vector<unsigned char> &tag) {
+    if(tag.size()<16) tag.resize(16);
     unsigned char *out = EncryptGCM (VectorToArray (in), (unsigned int)in.size(),
                                      VectorToArray (key), VectorToArray (iv),
                                      VectorToArray (aad), (unsigned int)aad.size(),
@@ -717,6 +718,7 @@ std::vector<unsigned char> AES::DecryptGCM (
         std::vector<unsigned char> iv,
         std::vector<unsigned char> aad,
         std::vector<unsigned char> tag) {
+    if(tag.size()<16) tag.resize(16);
     unsigned char *out = DecryptGCM (VectorToArray (in), (unsigned int)in.size(),
                                      VectorToArray (key), VectorToArray (iv),
                                      VectorToArray (aad), (unsigned int)aad.size(),


### PR DESCRIPTION
## Summary
- Guarantee vector-based GCM API resizes tag to 16 bytes if smaller

## Testing
- `make workflow_build_test`
- `./bin/test`
- `g++ /tmp/test_gcm.cpp src/AES.cpp -I. -o /tmp/test_gcm && /tmp/test_gcm`


------
https://chatgpt.com/codex/tasks/task_e_68b4f17bef68832ca5c737bb846d9f9e