### PR TITLE
fix(aes): include algorithm header

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -1,5 +1,6 @@
 #include "AES.h"
 #include <cstdint>
+#include <algorithm>
 
 AES::AES (const AESKeyLength keyLength) {
     switch (keyLength) {


### PR DESCRIPTION
## Summary
- include `<algorithm>` to allow use of `std::min` in AES implementation

## Testing
- `make workflow_build_test` (fails: fatal error: gtest/gtest.h: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68b4eba7b344832cb1aff6e3f43ee214