### PR TITLE
Remove obsolete GCM prototypes without authentication parameters

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -40,12 +40,6 @@ public:
                                const unsigned char key[], const unsigned char iv[]);
 
     unsigned char *EncryptGCM (const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char iv[]);
-
-    unsigned char *DecryptGCM (const unsigned char in[], unsigned int inLen,
-                               const unsigned char key[], const unsigned char iv[]);
-
-    unsigned char *EncryptGCM (const unsigned char in[], unsigned int inLen,
                                const unsigned char key[], const unsigned char iv[],
                                const unsigned char aad[], unsigned int aadLen,
                                unsigned char tag[]);


### PR DESCRIPTION
## Summary
- drop unused EncryptGCM and DecryptGCM declarations lacking AAD/tag parameters

## Testing
- `make workflow_build_test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f657f754832c8bcd6864eaf7d6a1