### PR TITLE
fix(gcm): correct reduction polynomial

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -334,7 +334,7 @@ void AES::EncryptBlock (const unsigned char in[], unsigned char out[],
 void AES::GF_Multiply (const unsigned char *X, const unsigned char *Y,
                        unsigned char *Z) {
     unsigned char V[16];
-    unsigned char R[16] = {0xE1}; // Полином: x^128 + x^7 + x^2 + x + 1
+    unsigned char R[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x87}; // Полином: x^128 + x^7 + x^2 + x + 1
     memset (Z, 0, 16);
     memcpy (V, Y, 16);
 


### PR DESCRIPTION
## Summary
- place 0x87 at the last byte of reduction polynomial used in GF(2^128)

## Testing
- `make workflow_build_test`
- `bin/test`
- `g++ /tmp/gcm_check.cpp -I. -o /tmp/gcm_check && /tmp/gcm_check`


------
https://chatgpt.com/codex/tasks/task_e_68b500e2ad74832c89250f66ea2b1441