### PR TITLE
chore(git): add clang-format pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+files="$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(c|cc|cpp|cxx|h|hpp)$' || true)"
+[ -z "$files" ] && exit 0
+# Use project .clang-format; fallback to LLVM if missing
+if command -v clang-format >/dev/null 2>&1; then
+  clang-format -style=file -i $files || clang-format -i $files
+else
+  echo "clang-format not found"; exit 1
+fi
+git add $files

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ Build commands:
 * `make speed_test` - run performance speed test
 * `make release` - run `release` version
 * `make clean` - clean `bin` directory
+
+To enable project hooks run:
+`git config core.hooksPath .githooks`


### PR DESCRIPTION
## Summary
- add pre-commit hook to run clang-format on staged C/C++ files
- document enabling git hooks

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*
- `make clean` *(fails: docker-compose: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b517b1e0bc832c9724c32165d53a48