### PR TITLE
fix(aesutils): use non-deterministic IV generator

### DIFF
--- a/src/AESUtils.h
+++ b/src/AESUtils.h
@@ -17,12 +17,19 @@ constexpr std::size_t BLOCK_SIZE = 16;
 
 inline std::array<uint8_t, BLOCK_SIZE> generate_iv() {
   std::array<uint8_t, BLOCK_SIZE> iv{};
-  auto seed = static_cast<uint32_t>(
-      std::chrono::steady_clock::now().time_since_epoch().count());
-  std::mt19937 generator(seed);
+  std::random_device rd;
   std::uniform_int_distribution<int> distribution(0, 255);
-  for (auto &byte : iv) {
-    byte = static_cast<uint8_t>(distribution(generator));
+  if (rd.entropy() > 0) {
+    for (auto &byte : iv) {
+      byte = static_cast<uint8_t>(distribution(rd));
+    }
+  } else {
+    auto seed = static_cast<unsigned long>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    std::mt19937 gen(seed);
+    for (auto &byte : iv) {
+      byte = static_cast<uint8_t>(distribution(gen));
+    }
   }
   return iv;
 }


### PR DESCRIPTION
## Summary
- Use `std::random_device` to fill IV bytes
- Fallback to time-seeded Mersenne Twister when `std::random_device` lacks entropy

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b536f45d70832c837ab274f7b8f351