### PR TITLE
feat(aes): cache round keys

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -25,15 +25,19 @@ AES::AES(const AESKeyLength keyLength) {
 unsigned char *AES::EncryptECB(const unsigned char in[], size_t inLen,
                                const unsigned char key[]) {
   CheckLength(inLen);
-  unsigned char *out = new unsigned char[inLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
-
-  for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    EncryptBlock(in + i, out + i, roundKeys);
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
   }
-
-  delete[] roundKeys;
+  unsigned char *out = new unsigned char[inLen];
+  for (size_t i = 0; i < inLen; i += blockBytesLen) {
+    EncryptBlock(in + i, out + i, cachedRoundKeys.data());
+  }
 
   return out;
 }
@@ -41,15 +45,19 @@ unsigned char *AES::EncryptECB(const unsigned char in[], size_t inLen,
 unsigned char *AES::DecryptECB(const unsigned char in[], size_t inLen,
                                const unsigned char key[]) {
   CheckLength(inLen);
-  unsigned char *out = new unsigned char[inLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
-
-  for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    DecryptBlock(in + i, out + i, roundKeys);
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
   }
-
-  delete[] roundKeys;
+  unsigned char *out = new unsigned char[inLen];
+  for (size_t i = 0; i < inLen; i += blockBytesLen) {
+    DecryptBlock(in + i, out + i, cachedRoundKeys.data());
+  }
 
   return out;
 }
@@ -58,19 +66,24 @@ unsigned char *AES::EncryptCBC(const unsigned char in[], size_t inLen,
                                const unsigned char key[],
                                const unsigned char *iv) {
   CheckLength(inLen);
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
   unsigned char block[blockBytesLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
 
   for (size_t i = 0; i < inLen; i += blockBytesLen) {
     XorBlocks(block, in + i, block, blockBytesLen);
-    EncryptBlock(block, out + i, roundKeys);
+    EncryptBlock(block, out + i, cachedRoundKeys.data());
     memcpy(block, out + i, blockBytesLen);
   }
-
-  delete[] roundKeys;
 
   return out;
 }
@@ -79,19 +92,24 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], size_t inLen,
                                const unsigned char key[],
                                const unsigned char *iv) {
   CheckLength(inLen);
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
   unsigned char block[blockBytesLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
 
   for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    DecryptBlock(in + i, out + i, roundKeys);
+    DecryptBlock(in + i, out + i, cachedRoundKeys.data());
     XorBlocks(block, out + i, out + i, blockBytesLen);
     memcpy(block, in + i, blockBytesLen);
   }
-
-  delete[] roundKeys;
 
   return out;
 }
@@ -99,21 +117,26 @@ unsigned char *AES::DecryptCBC(const unsigned char in[], size_t inLen,
 unsigned char *AES::EncryptCFB(const unsigned char in[], size_t inLen,
                                const unsigned char key[],
                                const unsigned char *iv) {
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
   unsigned char block[blockBytesLen];
   unsigned char encryptedBlock[blockBytesLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
 
   for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    EncryptBlock(block, encryptedBlock, roundKeys);
+    EncryptBlock(block, encryptedBlock, cachedRoundKeys.data());
     size_t blockLen = std::min<size_t>(blockBytesLen, inLen - i);
     XorBlocks(in + i, encryptedBlock, out + i, blockLen);
     memcpy(block, out + i, blockLen);
   }
-
-  delete[] roundKeys;
 
   return out;
 }
@@ -121,21 +144,26 @@ unsigned char *AES::EncryptCFB(const unsigned char in[], size_t inLen,
 unsigned char *AES::DecryptCFB(const unsigned char in[], size_t inLen,
                                const unsigned char key[],
                                const unsigned char *iv) {
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
   unsigned char block[blockBytesLen];
   unsigned char encryptedBlock[blockBytesLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
   memcpy(block, iv, blockBytesLen);
 
   for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    EncryptBlock(block, encryptedBlock, roundKeys);
+    EncryptBlock(block, encryptedBlock, cachedRoundKeys.data());
     size_t blockLen = std::min<size_t>(blockBytesLen, inLen - i);
     XorBlocks(in + i, encryptedBlock, out + i, blockLen);
     memcpy(block, in + i, blockLen);
   }
-
-  delete[] roundKeys;
 
   return out;
 }
@@ -143,16 +171,22 @@ unsigned char *AES::DecryptCFB(const unsigned char in[], size_t inLen,
 unsigned char *AES::EncryptCTR(const unsigned char in[], size_t inLen,
                                const unsigned char key[],
                                const unsigned char iv[]) {
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-
-  KeyExpansion(key, roundKeys);
   unsigned char counter[blockBytesLen];
   unsigned char encryptedCounter[blockBytesLen];
   memcpy(counter, iv, blockBytesLen);
 
   for (size_t i = 0; i < inLen; i += blockBytesLen) {
-    EncryptBlock(counter, encryptedCounter, roundKeys);
+    EncryptBlock(counter, encryptedCounter, cachedRoundKeys.data());
 
     size_t blockLen = std::min<size_t>(blockBytesLen, inLen - i);
     XorBlocks(in + i, encryptedCounter, out + i, blockLen);
@@ -163,8 +197,6 @@ unsigned char *AES::EncryptCTR(const unsigned char in[], size_t inLen,
       }
     }
   }
-
-  delete[] roundKeys;
 
   return out;
 }
@@ -180,14 +212,21 @@ unsigned char *AES::EncryptGCM(const unsigned char in[], size_t inLen,
                                const unsigned char iv[],
                                const unsigned char aad[], size_t aadLen,
                                unsigned char tag[]) {
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
 
   // Генерация H
   unsigned char H[16] = {0};
   unsigned char zeroBlock[16] = {0};
-  unsigned char *roundKeys = new unsigned char[4 * Nb * (Nr + 1)];
-  KeyExpansion(key, roundKeys);
-  EncryptBlock(zeroBlock, H, roundKeys);
+  EncryptBlock(zeroBlock, H, cachedRoundKeys.data());
 
   // Шифрование данных в режиме CTR
   unsigned char ctr[16] = {0};
@@ -196,7 +235,7 @@ unsigned char *AES::EncryptGCM(const unsigned char in[], size_t inLen,
 
   for (size_t i = 0; i < inLen; i += 16) {
     unsigned char encryptedCtr[16] = {0};
-    EncryptBlock(ctr, encryptedCtr, roundKeys);
+    EncryptBlock(ctr, encryptedCtr, cachedRoundKeys.data());
 
     size_t blockLen = std::min<size_t>(16, inLen - i);
     XorBlocks(in + i, encryptedCtr, out + i, blockLen);
@@ -229,12 +268,11 @@ unsigned char *AES::EncryptGCM(const unsigned char in[], size_t inLen,
   memcpy(J0, iv, 12);
   J0[15] = 1;
   unsigned char S[16] = {0};
-  EncryptBlock(J0, S, roundKeys);
+  EncryptBlock(J0, S, cachedRoundKeys.data());
   for (int i = 0; i < 16; i++) {
     tag[i] ^= S[i];
   }
 
-  delete[] roundKeys;
   delete[] ghashInput;
 
   return out;
@@ -245,14 +283,21 @@ unsigned char *AES::DecryptGCM(const unsigned char in[], size_t inLen,
                                const unsigned char iv[],
                                const unsigned char aad[], size_t aadLen,
                                const unsigned char tag[]) {
+  std::lock_guard<std::mutex> lock(cacheMutex);
+  const size_t keyLen = 4 * Nk;
+  if (cachedKey.size() != keyLen ||
+      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    cachedKey.assign(key, key + keyLen);
+    if (cachedRoundKeys.size() != 4 * Nb * (Nr + 1))
+      cachedRoundKeys.resize(4 * Nb * (Nr + 1));
+    KeyExpansion(key, cachedRoundKeys.data());
+  }
   unsigned char *out = new unsigned char[inLen];
 
   // Генерация H
   unsigned char H[16] = {0};
   unsigned char zeroBlock[16] = {0};
-  std::vector<unsigned char> roundKeys(4 * Nb * (Nr + 1));
-  KeyExpansion(key, roundKeys.data());
-  EncryptBlock(zeroBlock, H, roundKeys.data());
+  EncryptBlock(zeroBlock, H, cachedRoundKeys.data());
 
   // Расшифровка данных в режиме CTR
   unsigned char ctr[16] = {0};
@@ -261,7 +306,7 @@ unsigned char *AES::DecryptGCM(const unsigned char in[], size_t inLen,
 
   for (size_t i = 0; i < inLen; i += 16) {
     unsigned char encryptedCtr[16] = {0};
-    EncryptBlock(ctr, encryptedCtr, roundKeys.data());
+    EncryptBlock(ctr, encryptedCtr, cachedRoundKeys.data());
 
     size_t blockLen = std::min<size_t>(16, inLen - i);
     XorBlocks(in + i, encryptedCtr, out + i, blockLen);
@@ -295,7 +340,7 @@ unsigned char *AES::DecryptGCM(const unsigned char in[], size_t inLen,
   memcpy(J0, iv, 12);
   J0[15] = 1;
   unsigned char S[16] = {0};
-  EncryptBlock(J0, S, roundKeys.data());
+  EncryptBlock(J0, S, cachedRoundKeys.data());
   for (int i = 0; i < 16; i++) {
     calculatedTag[i] ^= S[i];
   }

--- a/src/AES.h
+++ b/src/AES.h
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -196,6 +197,10 @@ class AES {
   std::vector<unsigned char> ArrayToVector(unsigned char *a, size_t len);
 
   unsigned char *VectorToArray(std::vector<unsigned char> &a);
+
+  std::vector<unsigned char> cachedKey;
+  std::vector<unsigned char> cachedRoundKeys;
+  std::mutex cacheMutex;
 };
 
 const unsigned char sbox[16][16] = {


### PR DESCRIPTION
## Summary
- cache the last key and derived round keys in AES
- reuse cached key schedule across cipher modes
- guard key schedule with a mutex for thread safety

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b536a37654832c8a05c80ca5537f64