### PR TITLE
Add secure zeroing for AES sensitive buffers

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -14,6 +14,7 @@ enum class AESKeyLength { AES_128, AES_192, AES_256 };
 class AES {
  public:
   explicit AES(const AESKeyLength keyLength = AESKeyLength::AES_256);
+  ~AES();
 
   unsigned char *EncryptECB(const unsigned char in[], size_t inLen,
                             const unsigned char key[]);

--- a/src/secure_zero.h
+++ b/src/secure_zero.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+#if defined(__has_include)
+#if __has_include(<strings.h>)
+#include <strings.h>
+#endif
+#endif
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+inline void secure_zero(void *p, size_t n) {
+#if defined(_WIN32)
+  SecureZeroMemory(p, n);
+#elif defined(explicit_bzero) || defined(__GLIBC__) || defined(__APPLE__) || \
+    defined(__OpenBSD__) || defined(__FreeBSD__)
+  explicit_bzero(p, n);
+#elif defined(__STDC_LIB_EXT1__)
+  memset_s(p, n, 0, n);
+#else
+  volatile unsigned char *v = static_cast<volatile unsigned char *>(p);
+  while (n--) *v++ = 0;
+#endif
+}


### PR DESCRIPTION
## Summary
- add cross-platform `secure_zero` helper
- scrub round keys, IVs and GCM state before releasing memory
- clear plaintext/ciphertext buffers in utility helpers
- format sources with clang-format-17

## Testing
- `g++ -g -pthread ./src/AES.cpp ./tests/tests.cpp -lgtest -lgtest_main -o bin/test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b5432ad688832c9c24d6b42e79f14f