### PR TITLE
feat(gcm): support incremental ghash

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -192,6 +192,7 @@ class AES {
   void GF_Multiply(const unsigned char *X, const unsigned char *Y,
                    unsigned char *Z);
 
+  // Incrementally update GHASH state in `tag` with `len` bytes from `X`.
   void GHASH(const unsigned char *H, const unsigned char *X, size_t len,
              unsigned char *tag);
 


### PR DESCRIPTION
## Summary
- compute GHASH incrementally for AAD and ciphertext blocks
- remove monolithic ghashInput buffer in GCM encryption and decryption
- format source with clang-format-17

## Testing
- `g++ -Wall -Wextra -g -pthread ./src/AES.cpp ./tests/tests.cpp /usr/lib/x86_64-linux-gnu/libgtest.a -o bin/test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b550e288f8832caa59c607b55ef8fe