### PR TITLE
fix(aes): add constant-time tag comparison

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -288,7 +288,7 @@ unsigned char *AES::EncryptGCM(const unsigned char in[], size_t inLen,
   // Шифрование данных в режиме CTR
   unsigned char ctr[16] = {0};
   memcpy(ctr, iv, 12);  // IV занимает 12 байт
-  ctr[15] = 1;          // Установить начальное значение счетчика
+  ctr[15] = 1;  // Установить начальное значение счетчика
   unsigned char encryptedCtr[16] = {0};
 
   // GHASH для AAD

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -6,6 +6,15 @@
 
 #include "secure_zero.h"
 
+static bool constant_time_eq(const unsigned char *a, const unsigned char *b,
+                             size_t len) {
+  unsigned char diff = 0;
+  for (size_t i = 0; i < len; ++i) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff == 0;
+}
+
 AES::AES(const AESKeyLength keyLength) {
   switch (keyLength) {
     case AESKeyLength::AES_128:
@@ -279,7 +288,7 @@ unsigned char *AES::EncryptGCM(const unsigned char in[], size_t inLen,
   // Шифрование данных в режиме CTR
   unsigned char ctr[16] = {0};
   memcpy(ctr, iv, 12);  // IV занимает 12 байт
-  ctr[15] = 1;  // Установить начальное значение счетчика
+  ctr[15] = 1;          // Установить начальное значение счетчика
   unsigned char encryptedCtr[16] = {0};
 
   // GHASH для AAD
@@ -397,19 +406,7 @@ unsigned char *AES::DecryptGCM(const unsigned char in[], size_t inLen,
   for (int i = 0; i < 16; i++) {
     calculatedTag[i] ^= S[i];
   }
-
-  if (memcmp(tag, calculatedTag, 16) != 0) {
-    secure_zero(out.get(), inLen);
-    secure_zero(lenBlock, sizeof(lenBlock));
-    secure_zero(H, sizeof(H));
-    secure_zero(zeroBlock, sizeof(zeroBlock));
-    secure_zero(ctr, sizeof(ctr));
-    secure_zero(encryptedCtr, sizeof(encryptedCtr));
-    secure_zero(calculatedTag, sizeof(calculatedTag));
-    secure_zero(J0, sizeof(J0));
-    secure_zero(S, sizeof(S));
-    throw std::runtime_error("Authentication failed");
-  }
+  bool tagMatch = constant_time_eq(tag, calculatedTag, 16);
 
   secure_zero(lenBlock, sizeof(lenBlock));
   secure_zero(H, sizeof(H));
@@ -419,6 +416,12 @@ unsigned char *AES::DecryptGCM(const unsigned char in[], size_t inLen,
   secure_zero(calculatedTag, sizeof(calculatedTag));
   secure_zero(J0, sizeof(J0));
   secure_zero(S, sizeof(S));
+
+  if (!tagMatch) {
+    secure_zero(out.get(), inLen);
+    throw std::runtime_error("Authentication failed");
+  }
+
   return out.release();
 }
 


### PR DESCRIPTION
## Summary
- implement constant_time_eq helper for constant-time byte comparison
- use constant_time_eq in AES::DecryptGCM and always clear sensitive buffers

## Testing
- `g++ -Wall -Wextra -g -pthread ./src/AES.cpp ./tests/tests.cpp /usr/lib/x86_64-linux-gnu/libgtest.a -o bin/test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b55a1835ac832cabc8a9cafbfcf188