### PR TITLE
fix(gcm): enforce 12-byte IV for vector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ auto restored = aes.DecryptCBC(cipher.get(), sizeof(plain), key, iv);
 ```
 
 ### GCM Tagging
+GCM mode requires a 12-byte (96-bit) IV.
 ```c++
+unsigned char gcm_iv[12] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                             0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b };
 unsigned char tag[16];
 AES aesGcm(AESKeyLength::AES_128);
-auto cipherGcm = aesGcm.EncryptGCM(plain, sizeof(plain), key, iv, tag);
+auto cipherGcm =
+    aesGcm.EncryptGCM(plain, sizeof(plain), key, gcm_iv, tag);
 // 'tag' now contains the authentication tag for the ciphertext
 ```
 

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 
 #include "secure_zero.h"
 
@@ -931,6 +932,7 @@ std::vector<unsigned char> AES::EncryptGCM(
     const std::vector<unsigned char> &in, const std::vector<unsigned char> &key,
     const std::vector<unsigned char> &iv, const std::vector<unsigned char> &aad,
     std::vector<unsigned char> &tag) {
+  if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
   if (tag.size() < 16) tag.resize(16);
   std::unique_ptr<unsigned char[]> out(
       EncryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),
@@ -945,6 +947,7 @@ std::vector<unsigned char> AES::EncryptGCM(std::vector<unsigned char> &&in,
                                            std::vector<unsigned char> &&iv,
                                            std::vector<unsigned char> &&aad,
                                            std::vector<unsigned char> &tag) {
+  if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
   if (tag.size() < 16) tag.resize(16);
   std::unique_ptr<unsigned char[]> out(
       EncryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),
@@ -958,6 +961,7 @@ std::vector<unsigned char> AES::DecryptGCM(
     const std::vector<unsigned char> &in, const std::vector<unsigned char> &key,
     const std::vector<unsigned char> &iv, const std::vector<unsigned char> &aad,
     const std::vector<unsigned char> &tag) {
+  if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
   std::unique_ptr<unsigned char[]> out(
       DecryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),
                  aad.size(), tag.data()));
@@ -971,6 +975,7 @@ std::vector<unsigned char> AES::DecryptGCM(std::vector<unsigned char> &&in,
                                            std::vector<unsigned char> &&iv,
                                            std::vector<unsigned char> &&aad,
                                            std::vector<unsigned char> &&tag) {
+  if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
   if (tag.size() < 16) tag.resize(16);
   std::unique_ptr<unsigned char[]> out(
       DecryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),

--- a/src/AES.h
+++ b/src/AES.h
@@ -112,6 +112,7 @@ class AES {
                                         std::vector<unsigned char> &&key,
                                         std::vector<unsigned char> &&iv);
 
+  // GCM mode requires a 12-byte (96-bit) IV.
   std::vector<unsigned char> EncryptGCM(const std::vector<unsigned char> &in,
                                         const std::vector<unsigned char> &key,
                                         const std::vector<unsigned char> &iv,
@@ -124,6 +125,7 @@ class AES {
                                         std::vector<unsigned char> &&aad,
                                         std::vector<unsigned char> &tag);
 
+  // GCM mode requires a 12-byte (96-bit) IV.
   std::vector<unsigned char> DecryptGCM(const std::vector<unsigned char> &in,
                                         const std::vector<unsigned char> &key,
                                         const std::vector<unsigned char> &iv,


### PR DESCRIPTION
## Summary
- validate IV length for GCM vector overloads
- document the 12-byte IV requirement

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b56370db88832ca9709f065d0b1d7c