### PR TITLE
refactor(gcm): process GHASH blocks without buffering

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -194,7 +194,8 @@ class AES {
   void GF_Multiply(const unsigned char *X, const unsigned char *Y,
                    unsigned char *Z);
 
-  // Incrementally update GHASH state in `tag` with `len` bytes from `X`.
+  // Update GHASH state in `tag` with a single block of `len` bytes from `X`.
+  // `len` must be at most 16 and missing bytes are treated as zero.
   void GHASH(const unsigned char *H, const unsigned char *X, size_t len,
              unsigned char *tag);
 


### PR DESCRIPTION
## Summary
- stream AAD and ciphertext blocks directly into GHASH
- handle single-block GHASH updates
- document block-wise GHASH processing
- format AES.cpp with clang-format-17

## Testing
- `g++ -Wall -Wextra -g -pthread ./src/AES.cpp ./tests/tests.cpp -lgtest -o bin/test && bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5a9932c832c95fe512b45ffdde9