### PR TITLE
ci: add Windows Mingw workflow

### DIFF
--- a/.github/workflows/aes-ci-windows.yml
+++ b/.github/workflows/aes-ci-windows.yml
@@ -1,0 +1,45 @@
+name: CI Windows
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-gtest
+            mingw-w64-x86_64-clang
+      - name: Code style (check only)
+        run: |
+          files="$(git ls-files '*.h' '*.hpp' '*.c' '*.cc' '*.cpp' || true)"
+          [ -n "$files" ] && clang-format -style=file -n --Werror $files
+      - name: Prepare gtest
+        run: |
+          mkdir -p /usr/lib
+          if [ -f /mingw64/lib/libgtest.a ]; then
+            ln -s /mingw64/lib/libgtest.a /usr/lib/libgtest.a
+          else
+            ln -s /mingw64/lib/libgtest.dll.a /usr/lib/libgtest.a
+          fi
+      - name: Tests
+        run: |
+          make workflow_build_test
+          ./bin/test.exe
+      - name: Speed test
+        run: |
+          make workflow_build_speed_test
+          ./bin/speedtest.exe


### PR DESCRIPTION
## Summary
- add Windows CI workflow that builds and tests using mingw toolchain

## Testing
- `./bin/test`
- `./bin/speedtest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e31a5f94832c896eacc31376291c