### PR TITLE
refactor: centralize AES round key preparation

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -182,6 +182,9 @@ class AES {
 
   void KeyExpansion(const unsigned char key[], unsigned char w[]);
 
+  void prepare_round_keys(const unsigned char *key,
+                          std::vector<unsigned char> &roundKeys);
+
   void EncryptBlock(const unsigned char in[], unsigned char out[],
                     unsigned char *roundKeys);
 


### PR DESCRIPTION
## Summary
- add private `prepare_round_keys` to handle synchronized key expansion
- refactor all cipher modes to reuse cached round keys
- format AES.cpp with clang-format-17

## Testing
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e1d73014832c84d588198c0e41c9