### PR TITLE
fix(aes): correct ArrayToVector length

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -670,7 +670,7 @@ void AES::printHexVector(std::vector<unsigned char> &&a) {
 }
 
 std::vector<unsigned char> AES::ArrayToVector(unsigned char *a, size_t len) {
-  std::vector<unsigned char> v(a, a + len * sizeof(unsigned char));
+  std::vector<unsigned char> v(a, a + len);
   return v;
 }
 


### PR DESCRIPTION
## Summary
- use the supplied length directly in ArrayToVector
- format AES.cpp with clang-format-17

## Testing
- `g++ -std=c++17 tests/tests.cpp src/AES.cpp src/AESUtils.cpp -lgtest -lpthread -o tests/test_binary`
- `./tests/test_binary`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4e7f46c832c9c8e564c64a8958f