### PR TITLE
fix(gcm): validate tag length in vector wrappers

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -856,6 +856,8 @@ std::vector<unsigned char> AES::EncryptGCM(std::vector<unsigned char> &&in,
                                            std::vector<unsigned char> &&aad,
                                            std::vector<unsigned char> &tag) {
   if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
+  if (tag.size() > 16)
+    throw std::invalid_argument("Tag size must be at most 16 bytes");
   if (tag.size() < 16) tag.resize(16);
   std::unique_ptr<unsigned char[]> out(
       EncryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),
@@ -870,9 +872,13 @@ std::vector<unsigned char> AES::DecryptGCM(
     const std::vector<unsigned char> &iv, const std::vector<unsigned char> &aad,
     const std::vector<unsigned char> &tag) {
   if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
+  if (tag.size() > 16)
+    throw std::invalid_argument("Tag size must be at most 16 bytes");
+  std::vector<unsigned char> tagCopy = tag;
+  if (tagCopy.size() < 16) tagCopy.resize(16);
   std::unique_ptr<unsigned char[]> out(
       DecryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),
-                 aad.size(), tag.data()));
+                 aad.size(), tagCopy.data()));
   std::vector<unsigned char> v = ArrayToVector(out.get(), in.size());
   secure_zero(out.get(), in.size());
   return v;
@@ -884,6 +890,8 @@ std::vector<unsigned char> AES::DecryptGCM(std::vector<unsigned char> &&in,
                                            std::vector<unsigned char> &&aad,
                                            std::vector<unsigned char> &&tag) {
   if (iv.size() != 12) throw std::invalid_argument("IV size must be 12 bytes");
+  if (tag.size() > 16)
+    throw std::invalid_argument("Tag size must be at most 16 bytes");
   if (tag.size() < 16) tag.resize(16);
   std::unique_ptr<unsigned char[]> out(
       DecryptGCM(in.data(), in.size(), key.data(), iv.data(), aad.data(),

--- a/src/AESUtils.h
+++ b/src/AESUtils.h
@@ -21,15 +21,17 @@
 // --- Platform detection (pull headers only when relevant) ------------------
 #if defined(_WIN32)
 #if !defined(_WIN32_WINNT)
-#define _WIN32_WINNT 0x0600  // Vista+
+#define _WIN32_WINNT 0x0601  // Windows 7 or later
 #endif
 #if !defined(WINVER)
 #define WINVER _WIN32_WINNT
 #endif
 #if AESUTILS_HAS_INCLUDE(<bcrypt.h>)
 #define AESUTILS_HAVE_BCRYPT 1
-#include <bcrypt.h>
+// clang-format off
 #include <windows.h>
+#include <bcrypt.h>
+// clang-format on
 #if defined(_MSC_VER)
 #pragma comment(lib, "bcrypt")
 #endif


### PR DESCRIPTION
## Summary
- ensure GCM vector wrappers reject tags longer than 16 bytes
- pad short tags in const DecryptGCM wrapper before decryption
- include windows.h before bcrypt.h and target Windows 7+
- format sources with clang-format-17

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*
- `make workflow_build_test`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ee7c1418832cb4cbb12f921b9343