### PR TITLE
fix(ci): adjust gtest linking for Windows

### DIFF
--- a/.github/workflows/aes-ci-windows.yml
+++ b/.github/workflows/aes-ci-windows.yml
@@ -47,15 +47,6 @@ jobs:
             mingw-w64-x86_64-gtest
             git
 
-      - name: Prepare gtest
-        run: |
-          mkdir -p /usr/lib
-          if [ -f /mingw64/lib/libgtest.a ]; then
-            ln -s /mingw64/lib/libgtest.a /usr/lib/libgtest.a
-          else
-            ln -s /mingw64/lib/libgtest.dll.a /usr/lib/libgtest.a
-          fi
-
       - name: Tests
         run: |
           mingw32-make workflow_build_test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 FLAGS = -Wall -Wextra
 
+ifeq ($(OS),Windows_NT)
+GTEST_LIBS = -L/mingw64/lib -lgtest -lbcrypt
+else
+GTEST_LIBS = -pthread /usr/lib/libgtest.a
+endif
+
 build_all: clean build_test build_debug build_profile build_release build_speed_test
 
 build_test:
@@ -42,7 +48,7 @@ clean:
 
 
 workflow_build_test:
-	g++ $(FLAGS) -g -pthread ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp /usr/lib/libgtest.a -o bin/test
+	g++ $(FLAGS) -g ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp $(GTEST_LIBS) -o bin/test
 
 workflow_build_speed_test:
 	g++ $(FLAGS) -O2 ./src/AES.cpp ./src/AESUtils.cpp ./speedtest/main.cpp -o bin/speedtest


### PR DESCRIPTION
## Summary
- use platform-specific gtest flags in Makefile
- drop manual gtest symlink from Windows CI

## Testing
- `make workflow_build_test`
- `./bin/test`
- `make workflow_build_speed_test`
- `./bin/speedtest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f2b9fb58832c8c189b7e678c705e