### PR TITLE
docs: add OS build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # AES
 C++ AES(Advanced Encryption Standard) implementation  
  
-![Build Status](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml/badge.svg?branch=main)
+[![Ubuntu](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml)
+[![Windows](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml)
 
 ## Prerequisites
 * C++ compiler


### PR DESCRIPTION
## Summary
- show separate Ubuntu and Windows build status badges

## Testing
- `g++ -Wall -Wextra -g ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp -pthread /usr/lib/x86_64-linux-gnu/libgtest.a -o bin/test`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68b5fe905abc832c8b26230ec88ac003