### PR TITLE
fix: securely zero plaintext on padding failures

### DIFF
--- a/src/AESUtils.cpp
+++ b/src/AESUtils.cpp
@@ -248,9 +248,14 @@ std::vector<uint8_t> decrypt(const EncryptedData &data, const T &key,
                              decrypted.get() + data.ciphertext.size());
   secure_zero(decrypted.get(), data.ciphertext.size());
   if (mode == AesMode::CBC) {
-    auto result = remove_padding(plain);
-    secure_zero(plain.data(), plain.size());
-    return result;
+    try {
+      auto result = remove_padding(plain);
+      secure_zero(plain.data(), plain.size());
+      return result;
+    } catch (...) {
+      secure_zero(plain.data(), plain.size());
+      throw;
+    }
   }
   return plain;
 }


### PR DESCRIPTION
## Summary
- wrap CBC padding removal in try/catch to securely zero plaintext before rethrow
- preserve plaintext clearing after successful decryption

## Testing
- `make workflow_build_test`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68b5fc6b0844832cbaa3a943ea79fde4