### PR TITLE
feat: share AES round key cache

### DIFF
--- a/src/AES.h
+++ b/src/AES.h
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -184,8 +185,8 @@ class AES {
 
   void KeyExpansion(const unsigned char key[], unsigned char w[]);
 
-  void prepare_round_keys(const unsigned char *key,
-                          std::vector<unsigned char> &roundKeys);
+  std::shared_ptr<const std::vector<unsigned char>> prepare_round_keys(
+      const unsigned char *key);
 
   void EncryptBlock(const unsigned char in[], unsigned char out[],
                     unsigned char *roundKeys);
@@ -209,7 +210,7 @@ class AES {
   unsigned char *VectorToArray(std::vector<unsigned char> &a);
 
   std::vector<unsigned char> cachedKey;
-  std::vector<unsigned char> cachedRoundKeys;
+  std::shared_ptr<const std::vector<unsigned char>> cachedRoundKeys;
   std::mutex cacheMutex;
 };
 


### PR DESCRIPTION
## Summary
- return cached round keys via shared pointer
- use cached round keys directly in encrypt/decrypt routines without copying
- guard cache with mutex for thread-safe reuse
- format sources with clang-format-17

## Testing
- `./setup-hooks.sh`
- `g++ -std=c++17 -g ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp -lgtest -lgtest_main -pthread -o bin/test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b60698fdbc832cb1980a06d30fac12