### PR TITLE
refactor(namespace): wrap API in aescpp namespace

### DIFF
--- a/dev/main.cpp
+++ b/dev/main.cpp
@@ -4,5 +4,7 @@
 
 int main() {
   std::cout << "Aes dev" << std::endl;
+  aescpp::AES aes;
+  (void)aes;
   return 0;
 }

--- a/speedtest/main.cpp
+++ b/speedtest/main.cpp
@@ -34,7 +34,7 @@ int main() {
 
   unsigned char *plain = getRandomPlain(plainLength);
 
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned long start = getMicroseconds();
   unsigned char *out = aes.EncryptECB(plain, plainLength, key);
   unsigned long delta = getMicroseconds() - start;

--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -11,6 +11,8 @@
 #include <wmmintrin.h>
 #endif
 
+namespace aescpp {
+
 static bool constant_time_eq(const unsigned char *a, const unsigned char *b,
                              size_t len) {
   unsigned char diff = 0;
@@ -950,3 +952,5 @@ std::vector<unsigned char> AES::DecryptGCM(std::vector<unsigned char> &&in,
   secure_zero(out.get(), in.size());
   return v;
 }
+
+}  // namespace aescpp

--- a/src/AES.h
+++ b/src/AES.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+namespace aescpp {
+
 enum class AESKeyLength { AES_128, AES_192, AES_256 };
 
 class AES {
@@ -428,5 +430,7 @@ static const unsigned char CMDS[4][4] = {
 /// Inverse circulant MDS matrix
 static const unsigned char INV_CMDS[4][4] = {
     {14, 11, 13, 9}, {9, 14, 11, 13}, {13, 9, 14, 11}, {11, 13, 9, 14}};
+
+}  // namespace aescpp
 
 #endif

--- a/src/AESUtils.cpp
+++ b/src/AESUtils.cpp
@@ -2,6 +2,8 @@
 
 // Implementation for AES utility helpers.
 
+namespace aescpp {
+
 namespace aesutils {
 
 namespace detail {
@@ -315,3 +317,5 @@ template std::string decrypt_to_string<std::array<uint8_t, 32>>(
     const EncryptedData &, const std::array<uint8_t, 32> &, AesMode);
 
 }  // namespace aesutils
+
+}  // namespace aescpp

--- a/src/AESUtils.h
+++ b/src/AESUtils.h
@@ -55,6 +55,8 @@
 #include "AES.h"
 #include "secure_zero.h"
 
+namespace aescpp {
+
 namespace aesutils {
 
 constexpr std::size_t BLOCK_SIZE = 16;
@@ -115,3 +117,5 @@ std::string decrypt_to_string(const EncryptedData &data, const T &key,
                               AesMode mode);
 
 }  // namespace aesutils
+
+}  // namespace aescpp

--- a/src/secure_zero.h
+++ b/src/secure_zero.h
@@ -13,6 +13,8 @@
 #include <windows.h>
 #endif
 
+namespace aescpp {
+
 inline void secure_zero(void *p, size_t n) {
 #if defined(_WIN32)
   SecureZeroMemory(p, n);
@@ -26,3 +28,5 @@ inline void secure_zero(void *p, size_t n) {
   while (n--) *v++ = 0;
 #endif
 }
+
+}  // namespace aescpp

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -10,7 +10,7 @@
 const unsigned int BLOCK_BYTES_LENGTH = 16 * sizeof(unsigned char);
 
 TEST(KeyLengths, KeyLength128) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -24,7 +24,7 @@ TEST(KeyLengths, KeyLength128) {
 }
 
 TEST(KeyLengths, KeyLength192) {
-  AES aes(AESKeyLength::AES_192);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_192);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -39,7 +39,7 @@ TEST(KeyLengths, KeyLength192) {
 }
 
 TEST(KeyLengths, KeyLength256) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -55,7 +55,7 @@ TEST(KeyLengths, KeyLength256) {
 }
 
 TEST(ECB, EncryptDecryptOneBlock) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
 
@@ -72,7 +72,7 @@ TEST(ECB, EncryptDecryptOneBlock) {
 }
 
 TEST(ECB, EncryptDecryptVectorOneBlock) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   std::vector<unsigned char> plain = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                       0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                       0xcc, 0xdd, 0xee, 0xff};
@@ -88,7 +88,7 @@ TEST(ECB, EncryptDecryptVectorOneBlock) {
 }
 
 TEST(ECB, OneBlockEncrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -103,7 +103,7 @@ TEST(ECB, OneBlockEncrypt) {
 }
 
 TEST(ECB, OneBlockEncryptVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> plain = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                       0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                       0xcc, 0xdd, 0xee, 0xff};
@@ -119,7 +119,7 @@ TEST(ECB, OneBlockEncryptVector) {
 }
 
 TEST(ECB, OneBlockWithoutByteEncrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -131,7 +131,7 @@ TEST(ECB, OneBlockWithoutByteEncrypt) {
 }
 
 TEST(ECB, OneBlockPlusOneByteEncrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
                            0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0xaa};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -144,7 +144,7 @@ TEST(ECB, OneBlockPlusOneByteEncrypt) {
 }
 
 TEST(ECB, TwoBlocksEncrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
                            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
@@ -164,7 +164,7 @@ TEST(ECB, TwoBlocksEncrypt) {
 }
 
 TEST(ECB, OneBlockDecrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char encrypted[] = {0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30,
                                0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4, 0xc5, 0x5a};
   unsigned char key[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -179,7 +179,7 @@ TEST(ECB, OneBlockDecrypt) {
 }
 
 TEST(ECB, OneBlockDecryptVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> encrypted = {0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b,
                                           0x04, 0x30, 0xd8, 0xcd, 0xb7, 0x80,
                                           0x70, 0xb4, 0xc5, 0x5a};
@@ -195,7 +195,7 @@ TEST(ECB, OneBlockDecryptVector) {
 }
 
 TEST(ECB, TwoBlocksDecrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char encrypted[] = {
       0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30, 0xd8, 0xcd, 0xb7,
       0x80, 0x70, 0xb4, 0xc5, 0x5a, 0x07, 0xfe, 0xef, 0x74, 0xe1, 0xd5,
@@ -215,7 +215,7 @@ TEST(ECB, TwoBlocksDecrypt) {
 }
 
 TEST(CBC, EncryptDecrypt) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char iv[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -233,7 +233,7 @@ TEST(CBC, EncryptDecrypt) {
 }
 
 TEST(CBC, EncryptDecryptVector) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   std::vector<unsigned char> plain = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                       0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                       0xcc, 0xdd, 0xee, 0xff};
@@ -251,7 +251,7 @@ TEST(CBC, EncryptDecryptVector) {
 }
 
 TEST(CBC, TwoBlocksEncrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
                            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
@@ -271,7 +271,7 @@ TEST(CBC, TwoBlocksEncrypt) {
 }
 
 TEST(CBC, TwoBlocksEncryptVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> plain = {
       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
       0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
@@ -293,7 +293,7 @@ TEST(CBC, TwoBlocksEncryptVector) {
 }
 
 TEST(CBC, TwoBlocksDecrypt) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char encrypted[] = {0x1b, 0x87, 0x23, 0x78, 0x79, 0x5f, 0x4f, 0xfd,
                                0x77, 0x28, 0x55, 0xfc, 0x87, 0xca, 0x96, 0x4d,
                                0x4c, 0x5b, 0xca, 0x1c, 0x48, 0xcd, 0x88, 0x00,
@@ -316,7 +316,7 @@ TEST(CBC, TwoBlocksDecrypt) {
 }
 
 TEST(CBC, TwoBlocksDecryptVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> encrypted = {
       0x1b, 0x87, 0x23, 0x78, 0x79, 0x5f, 0x4f, 0xfd, 0x77, 0x28, 0x55,
       0xfc, 0x87, 0xca, 0x96, 0x4d, 0x4c, 0x5b, 0xca, 0x1c, 0x48, 0xcd,
@@ -339,7 +339,7 @@ TEST(CBC, TwoBlocksDecryptVector) {
 }
 
 TEST(CFB, EncryptDecrypt) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   unsigned char iv[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -357,7 +357,7 @@ TEST(CFB, EncryptDecrypt) {
 }
 
 TEST(CFB, EncryptDecryptVector) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   std::vector<unsigned char> plain = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
                                       0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
                                       0xcc, 0xdd, 0xee, 0xff};
@@ -375,7 +375,7 @@ TEST(CFB, EncryptDecryptVector) {
 }
 
 TEST(CFB, EncryptTwoBlocks) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
                            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
@@ -395,7 +395,7 @@ TEST(CFB, EncryptTwoBlocks) {
 }
 
 TEST(CFB, EncryptTwoBlocksVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> plain = {
       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
       0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
@@ -416,7 +416,7 @@ TEST(CFB, EncryptTwoBlocksVector) {
 }
 
 TEST(CFB, DecryptTwoBlocks) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   std::vector<unsigned char> encrypted = {
       0x3c, 0x55, 0x3d, 0x01, 0x8a, 0x52, 0xe4, 0x54, 0xec, 0x4e, 0x08,
       0x22, 0xc2, 0x8d, 0x55, 0xec, 0xe3, 0x5a, 0x40, 0xab, 0x30, 0x29,
@@ -437,7 +437,7 @@ TEST(CFB, DecryptTwoBlocks) {
 }
 
 TEST(CFB, DecryptTwoBlocksVector) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char encrypted[] = {0x3c, 0x55, 0x3d, 0x01, 0x8a, 0x52, 0xe4, 0x54,
                                0xec, 0x4e, 0x08, 0x22, 0xc2, 0x8d, 0x55, 0xec,
                                0xe3, 0x5a, 0x40, 0xab, 0x30, 0x29, 0xf3, 0x0c,
@@ -458,7 +458,7 @@ TEST(CFB, DecryptTwoBlocksVector) {
 }
 
 TEST(LongData, EncryptDecryptOneKb) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned int kbSize = 1024 * sizeof(unsigned char);
   unsigned char *plain = new unsigned char[kbSize];
   for (unsigned int i = 0; i < kbSize; i++) {
@@ -479,7 +479,7 @@ TEST(LongData, EncryptDecryptOneKb) {
 }
 
 TEST(LongData, EncryptDecryptVectorOneKb) {
-  AES aes(AESKeyLength::AES_256);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_256);
   unsigned int kbSize = 1024 * sizeof(unsigned char);
   std::vector<unsigned char> plain(kbSize);
   for (unsigned int i = 0; i < kbSize; i++) {
@@ -497,7 +497,7 @@ TEST(LongData, EncryptDecryptVectorOneKb) {
 }
 
 TEST(GCM, DecryptInvalidTag) {
-  AES aes(AESKeyLength::AES_128);
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[16] = {0};
   unsigned char key[16] = {0};
   unsigned char iv[12] = {0};
@@ -521,9 +521,10 @@ TEST(GCM, DecryptInvalidTag) {
 TEST(Utils, EncryptDecryptStringCBC) {
   std::string text = "hello world";
   std::array<uint8_t, 16> key = {0};
-  auto enc = aesutils::encrypt(text, key, aesutils::AesMode::CBC);
-  std::string dec =
-      aesutils::decrypt_to_string(enc, key, aesutils::AesMode::CBC);
+  auto enc =
+      aescpp::aesutils::encrypt(text, key, aescpp::aesutils::AesMode::CBC);
+  std::string dec = aescpp::aesutils::decrypt_to_string(
+      enc, key, aescpp::aesutils::AesMode::CBC);
   ASSERT_EQ(text, dec);
 }
 


### PR DESCRIPTION
## Summary
- wrap AES core classes, utilities, and helpers in aescpp namespace
- qualify examples and tests with new aescpp namespace
- format sources using clang-format-17

## Testing
- `g++ -std=c++17 -g ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp -o bin/test -pthread -lgtest`
- `g++ -std=c++17 -g ./src/AES.cpp ./src/AESUtils.cpp ./dev/main.cpp -o bin/debug`
- `g++ -std=c++17 -O2 ./src/AES.cpp ./src/AESUtils.cpp ./speedtest/main.cpp -o bin/speedtest -pthread`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b61824b948832cadbc194e637ea38d