### PR TITLE
refactor: streamline AESUtils includes

### DIFF
--- a/src/AESUtils.cpp
+++ b/src/AESUtils.cpp
@@ -15,8 +15,10 @@
 #endif
 #if AESUTILS_HAS_INCLUDE(<bcrypt.h>)
 #define AESUTILS_HAVE_BCRYPT 1
-#include <bcrypt.h>
+// clang-format off
 #include <windows.h>
+#include <bcrypt.h>
+// clang-format on
 #if defined(_MSC_VER)
 #pragma comment(lib, "bcrypt")
 #endif

--- a/src/AESUtils.cpp
+++ b/src/AESUtils.cpp
@@ -1,4 +1,57 @@
+#ifndef AESUTILS_HAS_INCLUDE
+#if defined(__has_include)
+#define AESUTILS_HAS_INCLUDE(x) __has_include(x)
+#else
+#define AESUTILS_HAS_INCLUDE(x) 0
+#endif
+#endif
+
+#if defined(_WIN32)
+#if !defined(_WIN32_WINNT)
+#define _WIN32_WINNT 0x0601  // Windows 7 or later
+#endif
+#if !defined(WINVER)
+#define WINVER _WIN32_WINNT
+#endif
+#if AESUTILS_HAS_INCLUDE(<bcrypt.h>)
+#define AESUTILS_HAVE_BCRYPT 1
+#include <bcrypt.h>
+#include <windows.h>
+#if defined(_MSC_VER)
+#pragma comment(lib, "bcrypt")
+#endif
+#endif
+#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || \
+    defined(__NetBSD__) || defined(__DragonFly__)
+#define AESUTILS_HAVE_ARC4RANDOM 1
+#include <stdlib.h>
+#elif defined(__linux__)
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#if AESUTILS_HAS_INCLUDE(<sys / random.h>)
+#define AESUTILS_HAVE_GETRANDOM 1
+#include <sys/random.h>
+#endif
+#endif
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+
 #include "AESUtils.h"
+
+#ifdef AESUTILS_TRUST_STD_RANDOM_DEVICE
+#include <random>
+#endif
+#ifdef AESUTILS_ALLOW_WEAK_FALLBACK
+#include <cstring>
+#if !defined(_WIN32)
+#include <unistd.h>
+#else
+#include <processthreadsapi.h>
+#endif
+#endif
 
 // Implementation for AES utility helpers.
 

--- a/src/AESUtils.h
+++ b/src/AESUtils.h
@@ -1,56 +1,10 @@
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
-#include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
-
-// --- feature-test wrapper for __has_include (C++11-safe) -----------------
-#ifndef AESUTILS_HAS_INCLUDE
-#if defined(__has_include)
-#define AESUTILS_HAS_INCLUDE(x) __has_include(x)
-#else
-#define AESUTILS_HAS_INCLUDE(x) 0
-#endif
-#endif
-
-// --- Platform detection (pull headers only when relevant) ------------------
-#if defined(_WIN32)
-#if !defined(_WIN32_WINNT)
-#define _WIN32_WINNT 0x0601  // Windows 7 or later
-#endif
-#if !defined(WINVER)
-#define WINVER _WIN32_WINNT
-#endif
-#if AESUTILS_HAS_INCLUDE(<bcrypt.h>)
-#define AESUTILS_HAVE_BCRYPT 1
-// clang-format off
-#include <windows.h>
-#include <bcrypt.h>
-// clang-format on
-#if defined(_MSC_VER)
-#pragma comment(lib, "bcrypt")
-#endif
-#endif
-#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || \
-    defined(__NetBSD__) || defined(__DragonFly__)
-#define AESUTILS_HAVE_ARC4RANDOM 1
-#include <stdlib.h>
-#elif defined(__linux__)
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
-// clang-format off
-#if AESUTILS_HAS_INCLUDE(<sys/random.h>)
-#define AESUTILS_HAVE_GETRANDOM 1
-#include <sys/random.h>
-#endif
-// clang-format on
-#endif
 
 #include "AES.h"
 #include "secure_zero.h"
@@ -65,19 +19,6 @@ namespace detail {
 bool fill_os_random(void *data, size_t len) noexcept;
 
 }  // namespace detail
-
-#ifdef AESUTILS_TRUST_STD_RANDOM_DEVICE
-#include <random>
-#endif
-#ifdef AESUTILS_ALLOW_WEAK_FALLBACK
-#include <chrono>
-#include <cstring>
-#if !defined(_WIN32)
-#include <unistd.h>
-#else
-#include <processthreadsapi.h>
-#endif
-#endif
 
 std::array<uint8_t, BLOCK_SIZE> generate_iv();
 std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data);


### PR DESCRIPTION
## Summary
- limit AESUtils.h to public interface headers
- move platform detection and random fallbacks into AESUtils.cpp

## Testing
- `g++ -std=c++17 ./src/AES.cpp ./src/AESUtils.cpp ./tests/tests.cpp -pthread /usr/lib/x86_64-linux-gnu/libgtest.a -o bin/test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b61e00a694832c85b551991b9d8fa3