### PR TITLE
feat: add ctr mode to aes utils

### DIFF
--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -34,7 +34,7 @@ struct EncryptedData {
   std::vector<uint8_t> ciphertext;
 };
 
-enum class AesMode { CBC, CFB };
+enum class AesMode { CBC, CFB, CTR };
 
 template <class T>
 AESKeyLength key_length_from_key(const T &key);

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -260,8 +260,13 @@ EncryptedData encrypt(const std::vector<uint8_t> &plain, const T &key,
       encrypted.reset(
           aes.EncryptCFB(src->data(), src->size(), key.data(), iv.data()));
       break;
+    case AesMode::CTR:
+      encrypted.reset(
+          aes.EncryptCTR(src->data(), src->size(), key.data(), iv.data()));
+      break;
     default:
-      throw std::invalid_argument("Invalid AES mode");
+      throw std::invalid_argument(
+          "Invalid AES mode; expected CBC, CFB, or CTR");
   }
 
   std::vector<uint8_t> ciphertext(encrypted.get(),
@@ -296,8 +301,14 @@ std::vector<uint8_t> decrypt(const EncryptedData &data, const T &key,
                                      data.ciphertext.size(), key.data(),
                                      data.iv.data()));
       break;
+    case AesMode::CTR:
+      decrypted.reset(aes.DecryptCTR(data.ciphertext.data(),
+                                     data.ciphertext.size(), key.data(),
+                                     data.iv.data()));
+      break;
     default:
-      throw std::invalid_argument("Invalid AES mode");
+      throw std::invalid_argument(
+          "Invalid AES mode; expected CBC, CFB, or CTR");
   }
 
   std::vector<uint8_t> plain(decrypted.get(),


### PR DESCRIPTION
## Summary
- support CTR encryption/decryption in AES utils
- expand AesMode enum for CTR and update error messages

## Testing
- `make workflow_build_test` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b64722c908832c8f0c33d84db3ddcf