### PR TITLE
feat(utils): support variable-length IV generation

### DIFF
--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -3,6 +3,7 @@
 #include <aescpp/aes.hpp>
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -19,6 +20,7 @@ bool fill_os_random(void *data, size_t len) noexcept;
 }  // namespace detail
 
 std::array<uint8_t, BLOCK_SIZE> generate_iv();
+std::vector<uint8_t> generate_iv(std::size_t len);
 std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data);
 std::vector<uint8_t> remove_padding(const std::vector<uint8_t> &data);
 std::vector<uint8_t> add_iv_to_ciphertext(

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -125,8 +125,13 @@ bool fill_os_random(void *data, size_t len) noexcept {
 
 }  // namespace detail
 
-std::array<uint8_t, BLOCK_SIZE> generate_iv() {
-  std::array<uint8_t, BLOCK_SIZE> iv{};
+std::vector<uint8_t> generate_iv(std::size_t len) {
+  if (len != 12 && len != BLOCK_SIZE) {
+    throw std::invalid_argument(
+        "Unsupported IV length; expected 12 or 16 bytes");
+  }
+
+  std::vector<uint8_t> iv(len);
 
   if (detail::fill_os_random(iv.data(), iv.size())) return iv;
 
@@ -171,6 +176,13 @@ std::array<uint8_t, BLOCK_SIZE> generate_iv() {
 
   throw std::runtime_error(
       "No secure random source available on this platform");
+}
+
+std::array<uint8_t, BLOCK_SIZE> generate_iv() {
+  auto iv_vec = generate_iv(BLOCK_SIZE);
+  std::array<uint8_t, BLOCK_SIZE> iv{};
+  std::copy_n(iv_vec.begin(), BLOCK_SIZE, iv.begin());
+  return iv;
 }
 
 std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data) {


### PR DESCRIPTION
## Summary
- add vector-based `generate_iv(len)` validating 12 or 16 byte IVs
- keep array-based helper and use it for 16-byte IVs
- include `<cstddef>` and format with clang-format-17

## Testing
- `make test` *(fails: docker daemon unavailable)*
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b6497b0db4832ca1301449de6fc4b6