### PR TITLE
test(utils): add CTR round-trip tests

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -527,6 +527,22 @@ TEST(Utils, EncryptDecryptStringCBC) {
   ASSERT_EQ(text, dec);
 }
 
+TEST(Utils, EncryptDecryptCtrZeroLength) {
+  std::vector<uint8_t> plain;
+  std::array<uint8_t, 16> key = {0};
+  auto enc = aescpp::utils::encrypt(plain, key, aescpp::utils::AesMode::CTR);
+  auto dec = aescpp::utils::decrypt(enc, key, aescpp::utils::AesMode::CTR);
+  ASSERT_EQ(dec, plain);
+}
+
+TEST(Utils, EncryptDecryptCtrNonBlockSize) {
+  std::vector<uint8_t> plain = {'n', 'o', 'n', 'b', 'l', 'o', 'c', 'k'};
+  std::array<uint8_t, 16> key = {0};
+  auto enc = aescpp::utils::encrypt(plain, key, aescpp::utils::AesMode::CTR);
+  auto dec = aescpp::utils::decrypt(enc, key, aescpp::utils::AesMode::CTR);
+  ASSERT_EQ(dec, plain);
+}
+
 TEST(Utils, EncryptDecryptStringGCM) {
   std::string text = "hello gcm";
   std::array<uint8_t, 16> key = {0};


### PR DESCRIPTION
## Summary
- add encryption/decryption round-trip tests for CTR mode
- cover empty and non-block-size plaintext cases

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b65236e5f8832c87f4f2b9f7406562