### PR TITLE
docs: clarify CFB and CTR length requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ auto plain = utils::decrypt_gcm_to_string(data, key, aad);
 
 
 # Padding
-This library does not provide any padding because padding is not part of AES standard. Plaintext and ciphertext length in bytes must be divisible by 16. If length doesn't satisfy this condition exception will be thrown
+This library does not provide any padding because padding is not part of AES standard.
+For ECB and CBC modes plaintext and ciphertext length in bytes must be divisible by
+16. CFB, CTR and GCM modes operate on data of any length. If the length for ECB or
+CBC doesn't satisfy this condition an exception will be thrown
 
 
 # Links

--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -74,7 +74,7 @@ class AES {
 
   /// \brief Encrypt data using CFB mode.
   /// \param in Input buffer.
-  /// \param inLen Length of input in bytes; must be divisible by 16.
+  /// \param inLen Length of input in bytes; may be any value.
   /// \param key Encryption key.
   /// \param iv Initialization vector (16 bytes).
   /// \return Newly allocated ciphertext; caller must delete[] using `delete[]`.
@@ -83,7 +83,7 @@ class AES {
 
   /// \brief Decrypt data encrypted with CFB mode.
   /// \param in Ciphertext buffer.
-  /// \param inLen Length of ciphertext in bytes; must be divisible by 16.
+  /// \param inLen Length of ciphertext in bytes; may be any value.
   /// \param key Decryption key.
   /// \param iv Initialization vector used for encryption (16 bytes).
   /// \return Newly allocated plaintext; caller must delete[] using `delete[]`.
@@ -92,7 +92,7 @@ class AES {
 
   /// \brief Encrypt data using CTR mode.
   /// \param in Input buffer.
-  /// \param inLen Length of input in bytes; must be divisible by 16.
+  /// \param inLen Length of input in bytes; may be any value.
   /// \param key Encryption key.
   /// \param iv Initialization vector (16 bytes).
   /// \return Newly allocated ciphertext; caller must delete[] using `delete[]`.
@@ -102,7 +102,7 @@ class AES {
 
   /// \brief Decrypt data encrypted with CTR mode.
   /// \param in Ciphertext buffer.
-  /// \param inLen Length of ciphertext in bytes; must be divisible by 16.
+  /// \param inLen Length of ciphertext in bytes; may be any value.
   /// \param key Decryption key.
   /// \param iv Initialization vector used for encryption (16 bytes).
   /// \return Newly allocated plaintext; caller must delete[] using `delete[]`.


### PR DESCRIPTION
## Summary
- document that CFB and CTR modes accept any input length
- update padding section to note only ECB and CBC require block-sized data

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b65ca3691c832c9a323c095a669f32