### PR TITLE
refactor(aes): use const round key pointers

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -322,7 +322,7 @@ class AES {
 
   void MixColumns(unsigned char state[4][Nb]);
 
-  void AddRoundKey(unsigned char state[4][Nb], unsigned char *key);
+  void AddRoundKey(unsigned char state[4][Nb], const unsigned char *key);
 
   void SubWord(unsigned char *a);
 
@@ -346,10 +346,10 @@ class AES {
       const unsigned char *key);
 
   void EncryptBlock(const unsigned char in[], unsigned char out[],
-                    unsigned char *roundKeys);
+                    const unsigned char *roundKeys);
 
   void DecryptBlock(const unsigned char in[], unsigned char out[],
-                    unsigned char *roundKeys);
+                    const unsigned char *roundKeys);
 
   void XorBlocks(const unsigned char *a, const unsigned char *b,
                  unsigned char *c, size_t len);
@@ -367,7 +367,7 @@ class AES {
   unsigned char *VectorToArray(std::vector<unsigned char> &a);
 
   std::vector<unsigned char> cachedKey;
-  std::shared_ptr<const std::vector<unsigned char>> cachedRoundKeys;
+  std::shared_ptr<std::vector<unsigned char>> cachedRoundKeys;
   std::mutex cacheMutex;
 };
 


### PR DESCRIPTION
## Summary
- refactor AES internals to accept const round key pointers
- cache round keys in mutable storage and wipe without const_cast

## Testing
- `g++ -std=c++17 -Iinclude -I/usr/include -pthread src/aes.cpp src/aes_utils.cpp tests/tests.cpp -lgtest -lgtest_main -o test_bin`
- `./test_bin`


------
https://chatgpt.com/codex/tasks/task_e_68b65c8b8148832c8155ba83b03894b4