### PR TITLE
perf(utils): batch random_device for IV generation

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -138,7 +138,14 @@ std::vector<uint8_t> generate_iv(std::size_t len) {
 #if defined(AESUTILS_TRUST_STD_RANDOM_DEVICE)
   {
     std::random_device rd;
-    for (auto &b : iv) b = static_cast<uint8_t>(rd());
+    std::size_t produced = 0;
+    while (produced < iv.size()) {
+      uint32_t r = rd();
+      std::size_t to_copy = std::min(iv.size() - produced, sizeof(r));
+      std::copy_n(reinterpret_cast<const uint8_t *>(&r), to_copy,
+                  iv.begin() + static_cast<std::ptrdiff_t>(produced));
+      produced += to_copy;
+    }
     return iv;
   }
 #endif


### PR DESCRIPTION
## Summary
- Batch `std::random_device` calls by filling the IV with 32-bit blocks
- Keep existing fallbacks when OS randomness and `std::random_device` are unavailable

## Testing
- `make test` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68b7011b9a64832cad1c82eb21a7085b