### PR TITLE
style: standardize include guards

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -1,5 +1,5 @@
-#ifndef _AES_H_
-#define _AES_H_
+#ifndef __AESCPP_AES_HPP_
+#define __AESCPP_AES_HPP_
 
 #include <array>
 #include <cstdint>
@@ -619,4 +619,4 @@ static const unsigned char INV_CMDS[4][4] = {
 
 }  // namespace aescpp
 
-#endif
+#endif  // __AESCPP_AES_HPP_

--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef __AESCPP_AES_UTILS_HPP_
+#define __AESCPP_AES_UTILS_HPP_
 
 #include <aescpp/aes.hpp>
 #include <array>
@@ -168,3 +169,5 @@ std::string decrypt_gcm_to_string(const GcmEncryptedData &data, const T &key,
 }  // namespace utils
 
 }  // namespace aescpp
+
+#endif  // __AESCPP_AES_UTILS_HPP_


### PR DESCRIPTION
## Summary
- align AES header guards with `__AESCPP_*_HPP_` convention
- replace `#pragma once` in utils header with explicit include guards

## Testing
- `clang-format -i include/aescpp/aes.hpp include/aescpp/aes_utils.hpp`
- `pre-commit run --files include/aescpp/aes.hpp include/aescpp/aes_utils.hpp` *(fails: .pre-commit-config.yaml is not a file)*
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b72dffe4d8832ca593871d3080ccc5