### PR TITLE
fix(utils): normalize sys/random include check

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -31,10 +31,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#if AESUTILS_HAS_INCLUDE(<sys / random.h>)
+// clang-format off
+#if AESUTILS_HAS_INCLUDE(<sys/random.h>)
 #define AESUTILS_HAVE_GETRANDOM 1
 #include <sys/random.h>
 #endif
+// clang-format on
 #endif
 
 #include <aescpp/aes_utils.hpp>


### PR DESCRIPTION
## Summary
- remove spaces in sys/random include conditional
- guard block with clang-format directives to keep formatting stable

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7300d3c44832c80ebfc4b255dfc93