### PR TITLE
fix(aes): zero cached key before reassigning

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -132,6 +132,7 @@ std::shared_ptr<const std::vector<unsigned char>> AES::prepare_round_keys(
   const size_t keyLen = 4 * Nk;
   if (cachedKey.size() != keyLen ||
       !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+    secure_zero(cachedKey.data(), cachedKey.size());
     cachedKey.assign(key, key + keyLen);
     auto newRoundKeys =
         std::make_shared<std::vector<unsigned char>>(4 * Nb * (Nr + 1));


### PR DESCRIPTION
## Summary
- secure zero cached key before assigning new key in `prepare_round_keys`

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7451485e0832c95e3f9afe88a1e96