### PR TITLE
refactor: use memcpy for key expansion

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -751,11 +751,7 @@ void AES::KeyExpansion(const unsigned char key[], unsigned char w[]) {
 
   unsigned int i = 0;
 
-  while (i < 4 * Nk) {
-    w[i] = key[i];
-    i++;
-  }
-
+  std::memcpy(w, key, 4 * Nk);
   i = 4 * Nk;
 
   while (i < 4 * Nb * (Nr + 1)) {


### PR DESCRIPTION
## Summary
- streamline AES key expansion by replacing byte-wise key copy loop with `std::memcpy`

## Testing
- `g++ -Wall -Wextra -I./include -c src/aes.cpp -o /tmp/aes.o`
- `g++ -Wall -Wextra -I./include -c src/aes_utils.cpp -o /tmp/aes_utils.o`


------
https://chatgpt.com/codex/tasks/task_e_68b747afee1c832c956a6e8f373bafc7