### PR TITLE
refactor(utils): drop zero-arg IV generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ portable software implementation is used instead.
 ECB, CBC, CFB, CTR and GCM modes are implemented. GCM additionally produces an authentication tag for message integrity.
 
 ## IV Generation
-`aescpp::utils` provides helpers for creating random IVs. `generate_iv()`
-returns a 16-byte IV suitable for block modes, while
-`generate_iv(len)` lets you request a specific length. Use 16 bytes for CBC,
-CFB and CTR; GCM recommends a 12-byte IV.
+`aescpp::utils` provides helpers for creating random IVs. `generate_iv(len)`
+lets you request a specific length. Use 16 bytes for CBC, CFB and CTR; GCM
+recommends a 12-byte IV.
 
 ## Vector Overloads
 All encryption and decryption methods have overloads that accept `std::vector<unsigned char>` in addition to raw pointer APIs:

--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -24,10 +24,6 @@ bool fill_os_random(void *data, size_t len) noexcept;
 
 }  // namespace detail
 
-/// \brief Generate a random 16-byte IV.
-/// \return Array containing the IV.
-std::array<uint8_t, BLOCK_SIZE> generate_iv();
-
 /// \brief Generate a random IV of specified length.
 /// \param len Required IV length in bytes.
 /// \return Vector containing the IV.

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -187,13 +187,6 @@ std::vector<uint8_t> generate_iv(std::size_t len) {
       "No secure random source available on this platform");
 }
 
-std::array<uint8_t, BLOCK_SIZE> generate_iv() {
-  auto iv_vec = generate_iv(BLOCK_SIZE);
-  std::array<uint8_t, BLOCK_SIZE> iv{};
-  std::copy_n(iv_vec.begin(), BLOCK_SIZE, iv.begin());
-  return iv;
-}
-
 std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data) {
   std::vector<uint8_t> padded = data;
   std::size_t padding = BLOCK_SIZE - (data.size() % BLOCK_SIZE);
@@ -263,7 +256,9 @@ template <class T>
 EncryptedData encrypt(const std::vector<uint8_t> &plain, const T &key,
                       AesMode mode) {
   AES aes(key_length_from_key(key));
-  auto iv = generate_iv();
+  auto iv_vec = generate_iv(BLOCK_SIZE);
+  std::array<uint8_t, BLOCK_SIZE> iv{};
+  std::copy_n(iv_vec.begin(), BLOCK_SIZE, iv.begin());
   const std::vector<uint8_t> *src = &plain;
   std::vector<uint8_t> padded;
   if (mode == AesMode::CBC) {


### PR DESCRIPTION
## Summary
- remove legacy generate_iv helper that returned fixed-size array
- update encrypt routine to build IV from length-based generator
- refresh documentation for single generate_iv API

## Testing
- `make test` *(fails: connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b74e9c7b50832c81fc479806fbf69e