### PR TITLE
fix(aes): use constant-time key comparison

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -131,7 +131,7 @@ std::shared_ptr<const std::vector<unsigned char>> AES::prepare_round_keys(
   std::lock_guard<std::mutex> lock(cacheMutex);
   const size_t keyLen = 4 * Nk;
   if (cachedKey.size() != keyLen ||
-      !std::equal(cachedKey.begin(), cachedKey.end(), key)) {
+      !constant_time_eq(cachedKey.data(), key, keyLen)) {
     secure_zero(cachedKey.data(), cachedKey.size());
     cachedKey.assign(key, key + keyLen);
     auto newRoundKeys =


### PR DESCRIPTION
## Summary
- use `constant_time_eq` instead of `std::equal` when checking cached keys

## Testing
- `make workflow_build_test`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68b7552bf124832c88cba248a8099179