### PR TITLE
feat(aes): add buffer-based encryption variants

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -376,6 +376,37 @@ class AES {
   std::shared_ptr<const std::vector<unsigned char>> prepare_round_keys(
       const unsigned char *key);
 
+  void EncryptECB(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], unsigned char out[]);
+  void DecryptECB(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], unsigned char out[]);
+  void EncryptCBC(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char *iv,
+                  unsigned char out[]);
+  void DecryptCBC(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char *iv,
+                  unsigned char out[]);
+  void EncryptCFB(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char *iv,
+                  unsigned char out[]);
+  void DecryptCFB(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char *iv,
+                  unsigned char out[]);
+  void EncryptCTR(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char iv[],
+                  unsigned char out[]);
+  void DecryptCTR(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char iv[],
+                  unsigned char out[]);
+  void EncryptGCM(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char iv[],
+                  const unsigned char aad[], size_t aadLen, unsigned char tag[],
+                  unsigned char out[]);
+  void DecryptGCM(const unsigned char in[], size_t inLen,
+                  const unsigned char key[], const unsigned char iv[],
+                  const unsigned char aad[], size_t aadLen,
+                  const unsigned char tag[], unsigned char out[]);
+
   void EncryptBlock(const unsigned char in[], unsigned char out[],
                     const unsigned char *roundKeys);
 


### PR DESCRIPTION
## Summary
- implement internal AES operations that write into caller-provided buffers
- simplify vector wrappers to fill pre-sized `std::vector` without intermediate allocations
- apply the same approach across CBC, CFB, CTR and GCM modes

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7599c5460832c9790232593c7fbdb