### PR TITLE
refactor(utils): use resize for padding

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -190,7 +190,7 @@ std::vector<uint8_t> generate_iv(std::size_t len) {
 std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data) {
   std::vector<uint8_t> padded = data;
   std::size_t padding = BLOCK_SIZE - (data.size() % BLOCK_SIZE);
-  padded.insert(padded.end(), padding, static_cast<uint8_t>(padding));
+  padded.resize(data.size() + padding, static_cast<uint8_t>(padding));
   return padded;
 }
 


### PR DESCRIPTION
## Summary
- replace manual padding insertion with std::vector::resize

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b75fb14970832ca21175242be62142