### PR TITLE
refactor: drop unused VectorToArray helper

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -424,9 +424,8 @@ class AES {
   void GHASH(const unsigned char *H, const unsigned char *X, size_t len,
              unsigned char *tag);
 
+  // Convert raw array to a std::vector.
   std::vector<unsigned char> ArrayToVector(unsigned char *a, size_t len);
-
-  unsigned char *VectorToArray(std::vector<unsigned char> &a);
 
   std::vector<unsigned char> cachedKey;
   std::shared_ptr<std::vector<unsigned char>> cachedRoundKeys;

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -956,11 +956,6 @@ std::vector<unsigned char> AES::ArrayToVector(unsigned char *a, size_t len) {
   std::vector<unsigned char> v(a, a + len);
   return v;
 }
-
-unsigned char *AES::VectorToArray(std::vector<unsigned char> &a) {
-  return a.data();
-}
-
 AESCPP_NODISCARD std::vector<unsigned char> AES::EncryptECB(
     const std::vector<unsigned char> &in,
     const std::vector<unsigned char> &key) {


### PR DESCRIPTION
## Summary
- remove unused VectorToArray helper and its declaration
- document the remaining ArrayToVector utility

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b762837f2c832c908a9036d39eb117