### PR TITLE
feat(utils): add fixed-size IV generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ portable software implementation is used instead.
 ECB, CBC, CFB, CTR and GCM modes are implemented. GCM additionally produces an authentication tag for message integrity.
 
 ## IV Generation
-`aescpp::utils` provides helpers for creating random IVs. `generate_iv(len)`
-lets you request a specific length. Use 16 bytes for CBC, CFB and CTR; GCM
-recommends a 12-byte IV.
+`aescpp::utils` provides helpers for creating random IVs. `generate_iv_16()`
+produces a 16-byte IV for CBC, CFB and CTR modes, while `generate_iv_12()`
+returns a 12-byte IV recommended for GCM.
 
 ## Vector Overloads
 All encryption and decryption methods have overloads that accept `std::vector<unsigned char>` in addition to raw pointer APIs:

--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -24,10 +24,13 @@ bool fill_os_random(void *data, size_t len) noexcept;
 
 }  // namespace detail
 
-/// \brief Generate a random IV of specified length.
-/// \param len Required IV length in bytes.
-/// \return Vector containing the IV.
-std::vector<uint8_t> generate_iv(std::size_t len);
+/// \brief Generate a random 12-byte IV.
+/// \return Array containing the IV.
+std::array<uint8_t, 12> generate_iv_12();
+
+/// \brief Generate a random 16-byte IV.
+/// \return Array containing the IV.
+std::array<uint8_t, 16> generate_iv_16();
 
 /// \brief Add PKCS#7 padding to data.
 /// \param data Input data.


### PR DESCRIPTION
## Summary
- replace generic IV generator with generate_iv_12 and generate_iv_16
- simplify encrypt helpers to use fixed-size IVs directly
- document IV helpers in README

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b76d557520832cb0c017c402d4d8bb