### PR TITLE
fix(gcm): increment counter before encryption

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -372,16 +372,15 @@ void AES::EncryptGCM(const unsigned char in[], size_t inLen,
   }
 
   for (size_t i = 0; i < inLen; i += 16) {
+    // Increment counter - GCM requires incrementing J0 before processing data
+    for (int j = 15; j >= 0; --j) {
+      if (++ctr[j]) break;
+    }
     EncryptBlock(ctr, encryptedCtr, roundKeys->data());
 
     size_t blockLen = std::min<size_t>(16, inLen - i);
     XorBlocks(in + i, encryptedCtr, out + i, blockLen);
     GHASH(H, out + i, blockLen, tag);
-
-    // Increment counter
-    for (int j = 15; j >= 0; --j) {
-      if (++ctr[j]) break;
-    }
   }
 
   unsigned char lenBlock[16] = {0};
@@ -447,16 +446,15 @@ void AES::DecryptGCM(const unsigned char in[], size_t inLen,
   }
 
   for (size_t i = 0; i < inLen; i += 16) {
+    // Increment counter - GCM requires incrementing J0 before processing data
+    for (int j = 15; j >= 0; --j) {
+      if (++ctr[j]) break;
+    }
     EncryptBlock(ctr, encryptedCtr, roundKeys->data());
 
     size_t blockLen = std::min<size_t>(16, inLen - i);
     XorBlocks(in + i, encryptedCtr, out + i, blockLen);
     GHASH(H, in + i, blockLen, calculatedTag);
-
-    // Increment counter
-    for (int j = 15; j >= 0; --j) {
-      if (++ctr[j]) break;
-    }
   }
 
   unsigned char lenBlock[16] = {0};


### PR DESCRIPTION
## Summary
- ensure GCM counter increments before block encryption
- document requirement to increment J0 prior to data processing

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*
- `make workflow_build_test` *(fails: fatal error: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b773614670832cb52715f5392c8a40