### PR TITLE
Use macros for cache locking to retain C++11 compatibility

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -8,6 +8,14 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#if __cplusplus >= 201703L
+#include <shared_mutex>
+#define AESCPP_SHARED_MUTEX std::shared_mutex
+#define AESCPP_SHARED_LOCK std::shared_lock
+#else
+#define AESCPP_SHARED_MUTEX std::mutex
+#define AESCPP_SHARED_LOCK std::unique_lock
+#endif
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -429,7 +437,7 @@ class AES {
 
   std::vector<unsigned char> cachedKey;
   std::shared_ptr<std::vector<unsigned char>> cachedRoundKeys;
-  std::mutex cacheMutex;
+  AESCPP_SHARED_MUTEX cacheMutex;
 };
 
 constexpr std::array<uint8_t, 256> sbox = {

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -128,8 +128,15 @@ AES::~AES() {
 
 std::shared_ptr<const std::vector<unsigned char>> AES::prepare_round_keys(
     const unsigned char *key) {
-  std::lock_guard<std::mutex> lock(cacheMutex);
   const size_t keyLen = 4 * Nk;
+  {
+    AESCPP_SHARED_LOCK<AESCPP_SHARED_MUTEX> lock(cacheMutex);
+    if (cachedKey.size() == keyLen &&
+        constant_time_eq(cachedKey.data(), key, keyLen)) {
+      return cachedRoundKeys;
+    }
+  }
+  std::unique_lock<AESCPP_SHARED_MUTEX> lock(cacheMutex);
   if (cachedKey.size() != keyLen ||
       !constant_time_eq(cachedKey.data(), key, keyLen)) {
     secure_zero(cachedKey.data(), cachedKey.size());


### PR DESCRIPTION
## Summary
- add macros mapping shared_mutex/shared_lock to fallback to mutex/unique_lock on pre-C++17
- apply macros to cacheMutex and round key locking

## Testing
- `make build_test` (fails: docker-compose: No such file or directory)
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b770bd77fc832c911d90d9bba4e707