### PR TITLE
fix(utils): validate block size before removing padding

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -201,6 +201,9 @@ std::vector<uint8_t> remove_padding(const std::vector<uint8_t> &data) {
   if (data.empty()) {
     throw std::invalid_argument("Data is empty, cannot remove padding.");
   }
+  if (data.size() % BLOCK_SIZE != 0) {
+    throw std::invalid_argument("Data size is not a multiple of block size.");
+  }
   uint8_t padding = data.back();
   bool invalid = padding == 0 || padding > BLOCK_SIZE || padding > data.size();
   uint8_t diff = 0;


### PR DESCRIPTION
## Summary
- validate data length is a multiple of BLOCK_SIZE before reading padding
- keep constant-time padding verification intact

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b77bc61a14832cba8e5ab0348becae