### PR TITLE
fix(gcm): handle overlapping buffers in GF_Multiply

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -666,11 +666,13 @@ void AES::GF_Multiply(const unsigned char *X, const unsigned char *Y,
   }
 #endif
   unsigned char V[16];
+  unsigned char X_copy[16];
+  memcpy(X_copy, X, 16);
   memset(Z, 0, 16);
   memcpy(V, Y, 16);
 
   for (int i = 0; i < 128; i++) {
-    if ((X[i / 8] >> (7 - (i % 8))) & 1) {
+    if ((X_copy[i / 8] >> (7 - (i % 8))) & 1) {
       for (int j = 0; j < 16; j++) {
         Z[j] ^= V[j];
       }
@@ -692,6 +694,7 @@ void AES::GF_Multiply(const unsigned char *X, const unsigned char *Y,
       }
     }
   }
+  secure_zero(X_copy, sizeof(X_copy));
   secure_zero(V, sizeof(V));
 }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -568,6 +568,23 @@ TEST(Utils, DecryptStringGcmTagMismatch) {
   EXPECT_THROW(aescpp::utils::decrypt_gcm(enc, key), std::runtime_error);
 }
 
+TEST(Utils, DecryptStringGcmCiphertextMismatch) {
+  std::string text = "hello gcm";
+  std::array<uint8_t, 16> key = {0};
+  auto enc = aescpp::utils::encrypt_gcm(text, key);
+  enc.ciphertext[0] ^= 0x01;
+  EXPECT_THROW(aescpp::utils::decrypt_gcm(enc, key), std::runtime_error);
+}
+
+TEST(Utils, DecryptStringGcmAadMismatch) {
+  std::string text = "hello gcm";
+  std::array<uint8_t, 16> key = {0};
+  std::vector<uint8_t> aad = {1, 2, 3};
+  auto enc = aescpp::utils::encrypt_gcm(text, key, aad);
+  aad[0] ^= 0x01;
+  EXPECT_THROW(aescpp::utils::decrypt_gcm(enc, key, aad), std::runtime_error);
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- preserve input in GF_Multiply by copying to a temp buffer before zeroing output
- add GCM regression tests ensuring ciphertext or AAD tampering changes tag

## Testing
- `make workflow_build_test CXXFLAGS=-U__PCLMUL__`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b78544ec20832c9abdb4e1a1a0619e