### PR TITLE
fix(aes): make constant_time_eq branchless

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -56,13 +56,13 @@ void secure_zero(void *p, size_t n) {
 #endif
 }
 
-static bool constant_time_eq(const unsigned char *a, const unsigned char *b,
-                             size_t len) {
-  unsigned char diff = 0;
+bool constant_time_eq(const unsigned char *a, const unsigned char *b,
+                      size_t len) {
+  uint32_t diff = 0;
   for (size_t i = 0; i < len; ++i) {
-    diff |= a[i] ^ b[i];
+    diff |= static_cast<uint32_t>(a[i] ^ b[i]);
   }
-  return diff == 0;
+  return ((diff - 1) >> 8) & 1;
 }
 
 #if defined(__AES__) && (defined(__x86_64__) || defined(_M_X64) || \

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -9,6 +9,21 @@
 
 const unsigned int BLOCK_BYTES_LENGTH = 16 * sizeof(unsigned char);
 
+namespace aescpp {
+bool constant_time_eq(const unsigned char *a, const unsigned char *b,
+                      size_t len);
+}
+
+TEST(Internal, ConstantTimeEq) {
+  unsigned char a[] = {0x00, 0x01, 0x02, 0x03};
+  unsigned char b[] = {0x00, 0x01, 0x02, 0x03};
+  unsigned char c[] = {0x00, 0x01, 0x02, 0x04};
+  // Equal buffers must compare as equal.
+  EXPECT_TRUE(aescpp::constant_time_eq(a, b, sizeof(a)));
+  // A differing byte must result in inequality.
+  EXPECT_FALSE(aescpp::constant_time_eq(a, c, sizeof(a)));
+}
+
 TEST(KeyLengths, KeyLength128) {
   aescpp::AES aes(aescpp::AESKeyLength::AES_128);
   unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,


### PR DESCRIPTION
## Summary
- eliminate branch in `constant_time_eq` by replacing the final comparison with a mask-based expression
- add unit test covering equality and inequality cases

## Testing
- `make workflow_build_test`
- `./bin/test`
- `objdump -d /tmp/aes.o | sed -n '/_ZN6aescpp16constant_time_eqEPKhS1_m/,+20p'`


------
https://chatgpt.com/codex/tasks/task_e_68b785aeb534832ca15d21de7a8dd864