### PR TITLE
fix(gcm): support in-place decryption

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -496,8 +496,10 @@ void AES::DecryptGCM(const unsigned char in[], size_t inLen,
     EncryptBlock(ctr, encryptedCtr, roundKeys->data());
 
     size_t blockLen = std::min<size_t>(16, inLen - i);
-    XorBlocks(in + i, encryptedCtr, out + i, blockLen);
+    // GHASH must run on the ciphertext before it may be overwritten by
+    // XorBlocks when operating in-place.
     GHASH(H, in + i, blockLen, calculatedTag);
+    XorBlocks(in + i, encryptedCtr, out + i, blockLen);
   }
 
   unsigned char lenBlock[16] = {0};

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -533,6 +533,23 @@ TEST(GCM, DecryptInvalidTag) {
   delete[] cipher;
 }
 
+TEST(GCM, DecryptInPlace) {
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
+  unsigned char plain[32];
+  for (size_t i = 0; i < sizeof(plain); ++i) {
+    plain[i] = static_cast<unsigned char>(i);
+  }
+  unsigned char key[16] = {0};
+  unsigned char iv[12] = {0};
+  unsigned char tag[16];
+  unsigned char buffer[sizeof(plain)];
+
+  aes.EncryptGCM(plain, sizeof(plain), key, iv, nullptr, 0, tag, buffer);
+  aes.DecryptGCM(buffer, sizeof(buffer), key, iv, nullptr, 0, tag, buffer);
+
+  ASSERT_FALSE(memcmp(buffer, plain, sizeof(plain)));
+}
+
 TEST(Utils, EncryptDecryptStringCBC) {
   std::string text = "hello world";
   std::array<uint8_t, 16> key = {0};


### PR DESCRIPTION
## Summary
- compute GHASH on ciphertext before XOR to allow in-place GCM decryption
- add unit test for in-place GCM decrypt

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b78a3982d8832c875e4172c3297a02