### PR TITLE
fix(gcm): enforce maximum message length

### DIFF
--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -207,6 +207,7 @@ class AES {
   /// \param aadLen Length of \p aad in bytes.
   /// \param tag Output buffer for 16-byte authentication tag.
   /// \return Newly allocated ciphertext; caller must delete[] using `delete[]`.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
   /// \note IV length must be exactly 12 bytes.
   AESCPP_NODISCARD unsigned char *EncryptGCM(
       const unsigned char in[], size_t inLen, const unsigned char key[],
@@ -224,6 +225,7 @@ class AES {
   /// \param tag Expected 16-byte authentication tag.
   /// \return Newly allocated plaintext; caller must delete[] using `delete[]`.
   /// \throws std::runtime_error If authentication fails.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
   /// \note IV length must be exactly 12 bytes.
   AESCPP_NODISCARD unsigned char *DecryptGCM(
       const unsigned char in[], size_t inLen, const unsigned char key[],
@@ -351,6 +353,7 @@ class AES {
   /// \param aad Additional authenticated data.
   /// \param tag Output tag resized to 16 bytes.
   /// \return Ciphertext of the same length as \p in.
+  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes.
   /// \note IV must be 12 bytes.
   AESCPP_NODISCARD std::vector<unsigned char> EncryptGCM(
       const std::vector<unsigned char> &in,
@@ -372,6 +375,7 @@ class AES {
   /// \param tag Authentication tag to verify.
   /// \return Plaintext of the same length as \p in.
   /// \throws std::runtime_error If authentication fails.
+  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes.
   /// \note IV must be 12 bytes.
   AESCPP_NODISCARD std::vector<unsigned char> DecryptGCM(
       const std::vector<unsigned char> &in,
@@ -396,6 +400,7 @@ class AES {
   /// \param aadLen Length of \p aad in bytes.
   /// \param tag Output buffer for the 16-byte authentication tag.
   /// \param out Output buffer with space for \p inLen bytes of ciphertext.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
   /// \note IV length must be exactly 12 bytes.
   void EncryptGCM(const unsigned char in[], size_t inLen,
                   const unsigned char key[], const unsigned char iv[],
@@ -412,6 +417,7 @@ class AES {
   /// \param tag Expected 16-byte authentication tag.
   /// \param out Output buffer with space for \p inLen bytes of plaintext.
   /// \throws std::runtime_error If authentication fails.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
   /// \note IV length must be exactly 12 bytes.
   void DecryptGCM(const unsigned char in[], size_t inLen,
                   const unsigned char key[], const unsigned char iv[],

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -395,6 +395,7 @@ void AES::EncryptGCM(const unsigned char in[], size_t inLen,
   if (!key) throw std::invalid_argument("Null key");
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
+  if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
   auto roundKeys = prepare_round_keys(key);
 
   // Compute hash subkey H
@@ -469,6 +470,7 @@ void AES::DecryptGCM(const unsigned char in[], size_t inLen,
   if (!key) throw std::invalid_argument("Null key");
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
+  if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
   auto roundKeys = prepare_round_keys(key);
 
   // Compute hash subkey H

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -550,6 +550,22 @@ TEST(GCM, DecryptInPlace) {
   ASSERT_FALSE(memcmp(buffer, plain, sizeof(plain)));
 }
 
+TEST(GCM, InputTooLong) {
+  aescpp::AES aes(aescpp::AESKeyLength::AES_128);
+  unsigned char in[16] = {0};
+  unsigned char out[16];
+  unsigned char key[16] = {0};
+  unsigned char iv[12] = {0};
+  unsigned char tag[16] = {0};
+  size_t tooLong = ((1ULL << 32) * 16) + 1;
+
+  EXPECT_THROW(aes.EncryptGCM(in, tooLong, key, iv, nullptr, 0, tag, out),
+               std::length_error);
+
+  EXPECT_THROW(aes.DecryptGCM(in, tooLong, key, iv, nullptr, 0, tag, out),
+               std::length_error);
+}
+
 TEST(Utils, EncryptDecryptStringCBC) {
   std::string text = "hello world";
   std::array<uint8_t, 16> key = {0};


### PR DESCRIPTION
## Summary
- guard GCM encrypt/decrypt against messages larger than 2^32 blocks
- document GCM maximum message size and related exceptions
- test that overly long messages raise std::length_error

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b78c777aac832c9baa637d76e19790