### PR TITLE
fix(aes): reset cached round keys

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -182,6 +182,7 @@ std::shared_ptr<const std::vector<unsigned char>> AES::prepare_round_keys(
     KeyExpansion(key, newRoundKeys->data());
     if (cachedRoundKeys) {
       secure_zero(cachedRoundKeys->data(), cachedRoundKeys->size());
+      cachedRoundKeys.reset();
     }
     cachedRoundKeys = newRoundKeys;
   }


### PR DESCRIPTION
## Summary
- reset cached round keys shared pointer after zeroing before assigning new key schedule

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b791e20a40832cb2643ba8f5363370