### PR TITLE
fix: handle CTR counter overflow

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -362,10 +362,15 @@ void AES::EncryptCTR(const unsigned char in[], size_t inLen,
     size_t blockLen = std::min<size_t>(blockBytesLen, inLen - i);
     XorBlocks(in + i, encryptedCounter, out + i, blockLen);
 
+    bool overflow = true;  // detect counter wrap-around
     for (int j = blockBytesLen - 1; j >= 0; --j) {
       if (++counter[j] != 0) {
+        overflow = false;
         break;
       }
+    }
+    if (overflow) {
+      throw std::length_error("CTR counter overflow");
     }
   }
 


### PR DESCRIPTION
## Summary
- detect counter overflow in AES::EncryptCTR and throw std::length_error
- document wrap-around detection for the counter

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b791da8418832caa450450ce5b9888