### PR TITLE
fix(aes): enforce GCM length limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ auto restored =
 
 ### GCM Helpers
 `encrypt_gcm` and `decrypt_gcm` manage the 12-byte IV, optional additional
-authenticated data (AAD), and the authentication tag produced by GCM:
+authenticated data (AAD), and the authentication tag produced by GCM.
+
+GCM limits AAD to `(1ULL << 39) - 256` bytes and the combined length of AAD and
+plaintext to the same bound. The library throws `std::length_error` if these
+limits are exceeded:
 ```c++
 #include <aescpp/aes_utils.hpp>
 

--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -207,7 +207,9 @@ class AES {
   /// \param aadLen Length of \p aad in bytes.
   /// \param tag Output buffer for 16-byte authentication tag.
   /// \return Newly allocated ciphertext; caller must delete[] using `delete[]`.
-  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aadLen exceeds (1ULL << 39) - 256 bytes, or if \p aadLen + \p inLen
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV length must be exactly 12 bytes.
   AESCPP_NODISCARD unsigned char *EncryptGCM(
       const unsigned char in[], size_t inLen, const unsigned char key[],
@@ -225,7 +227,9 @@ class AES {
   /// \param tag Expected 16-byte authentication tag.
   /// \return Newly allocated plaintext; caller must delete[] using `delete[]`.
   /// \throws std::runtime_error If authentication fails.
-  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aadLen exceeds (1ULL << 39) - 256 bytes, or if \p aadLen + \p inLen
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV length must be exactly 12 bytes.
   AESCPP_NODISCARD unsigned char *DecryptGCM(
       const unsigned char in[], size_t inLen, const unsigned char key[],
@@ -353,7 +357,9 @@ class AES {
   /// \param aad Additional authenticated data.
   /// \param tag Output tag resized to 16 bytes.
   /// \return Ciphertext of the same length as \p in.
-  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aad exceeds (1ULL << 39) - 256 bytes, or if the sum of \p aad and \p in
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV must be 12 bytes.
   AESCPP_NODISCARD std::vector<unsigned char> EncryptGCM(
       const std::vector<unsigned char> &in,
@@ -375,7 +381,9 @@ class AES {
   /// \param tag Authentication tag to verify.
   /// \return Plaintext of the same length as \p in.
   /// \throws std::runtime_error If authentication fails.
-  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If the input exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aad exceeds (1ULL << 39) - 256 bytes, or if the sum of \p aad and \p in
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV must be 12 bytes.
   AESCPP_NODISCARD std::vector<unsigned char> DecryptGCM(
       const std::vector<unsigned char> &in,
@@ -400,7 +408,9 @@ class AES {
   /// \param aadLen Length of \p aad in bytes.
   /// \param tag Output buffer for the 16-byte authentication tag.
   /// \param out Output buffer with space for \p inLen bytes of ciphertext.
-  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aadLen exceeds (1ULL << 39) - 256 bytes, or if \p aadLen + \p inLen
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV length must be exactly 12 bytes.
   void EncryptGCM(const unsigned char in[], size_t inLen,
                   const unsigned char key[], const unsigned char iv[],
@@ -417,7 +427,9 @@ class AES {
   /// \param tag Expected 16-byte authentication tag.
   /// \param out Output buffer with space for \p inLen bytes of plaintext.
   /// \throws std::runtime_error If authentication fails.
-  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes.
+  /// \throws std::length_error If \p inLen exceeds (1ULL << 32) * 16 bytes, if
+  /// \p aadLen exceeds (1ULL << 39) - 256 bytes, or if \p aadLen + \p inLen
+  /// exceeds (1ULL << 39) - 256 bytes.
   /// \note IV length must be exactly 12 bytes.
   void DecryptGCM(const unsigned char in[], size_t inLen,
                   const unsigned char key[], const unsigned char iv[],

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -405,6 +405,10 @@ void AES::EncryptGCM(const unsigned char in[], size_t inLen,
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
   if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
+  const uint64_t gcmLimit = (1ULL << 39) - 256;
+  if (aadLen > gcmLimit) throw std::length_error("AAD too long");
+  if (aadLen + inLen > gcmLimit)
+    throw std::length_error("AAD + input too long");
   auto roundKeys = prepare_round_keys(key);
 
   // Compute hash subkey H
@@ -480,6 +484,10 @@ void AES::DecryptGCM(const unsigned char in[], size_t inLen,
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
   if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
+  const uint64_t gcmLimit = (1ULL << 39) - 256;
+  if (aadLen > gcmLimit) throw std::length_error("AAD too long");
+  if (aadLen + inLen > gcmLimit)
+    throw std::length_error("AAD + input too long");
   auto roundKeys = prepare_round_keys(key);
 
   // Compute hash subkey H


### PR DESCRIPTION
## Summary
- validate AAD length and total message length against GCM limits in EncryptGCM and DecryptGCM
- document GCM length checks in API Doxygen comments and README

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b791f0c50c832c8ca27561423d2d03