### PR TITLE
docs: deprecate ECB mode and recommend authenticated encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ portable software implementation is used instead.
 
 ## Supported Modes
 ECB, CBC, CFB, CTR and GCM modes are implemented. GCM additionally produces an authentication tag for message integrity.
+ECB mode is provided for completeness but leaks plaintext patterns and should be avoided. Prefer authenticated encryption modes such as GCM that provide both confidentiality and integrity.
 
 ## IV Generation
 `aescpp::utils` provides helpers for creating random IVs. `generate_iv_16()`

--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -32,6 +32,12 @@
 #define AESCPP_MAKE_UNIQUE(T, n) std::unique_ptr<T[]>(new T[n])
 #endif
 
+#if __cplusplus >= 201402L
+#define AESCPP_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define AESCPP_DEPRECATED(msg)
+#endif
+
 namespace aescpp {
 
 /// \brief Overwrite a memory region with zeros.
@@ -59,22 +65,28 @@ class AES {
   ~AES();
 
   /// \brief Encrypt data using ECB mode.
+  /// \warning ECB mode leaks plaintext patterns and should not be used for new
+  ///          code. Prefer an authenticated mode like GCM.
   /// \param in Input buffer.
   /// \param inLen Length of input in bytes; must be divisible by 16.
   /// \param key Encryption key.
   /// \return Newly allocated ciphertext; caller must delete[] using `delete[]`.
-  AESCPP_NODISCARD unsigned char *EncryptECB(const unsigned char in[],
-                                             size_t inLen,
-                                             const unsigned char key[]);
+  AESCPP_NODISCARD AESCPP_DEPRECATED(
+      "ECB mode leaks plaintext patterns; use an authenticated mode like "
+      "GCM") unsigned char *EncryptECB(const unsigned char in[], size_t inLen,
+                                       const unsigned char key[]);
 
   /// \brief Decrypt data previously encrypted with ECB mode.
+  /// \warning ECB mode leaks plaintext patterns and should not be used for new
+  ///          code. Prefer an authenticated mode like GCM.
   /// \param in Ciphertext buffer.
   /// \param inLen Length of ciphertext in bytes; must be divisible by 16.
   /// \param key Decryption key.
   /// \return Newly allocated plaintext; caller must delete[] using `delete[]`.
-  AESCPP_NODISCARD unsigned char *DecryptECB(const unsigned char in[],
-                                             size_t inLen,
-                                             const unsigned char key[]);
+  AESCPP_NODISCARD AESCPP_DEPRECATED(
+      "ECB mode leaks plaintext patterns; use an authenticated mode like "
+      "GCM") unsigned char *DecryptECB(const unsigned char in[], size_t inLen,
+                                       const unsigned char key[]);
 
   /// \brief Encrypt data using CBC mode.
   /// \param in Input buffer.


### PR DESCRIPTION
## Summary
- deprecate `EncryptECB` and `DecryptECB` and warn that ECB reveals plaintext patterns
- advise in README to use authenticated modes like GCM instead of ECB

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b798142a20832c95df9d6c85a9c118