### PR TITLE
fix(utils): return padding status instead of exceptions

### DIFF
--- a/include/aescpp/aes_utils.hpp
+++ b/include/aescpp/aes_utils.hpp
@@ -39,8 +39,10 @@ std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data);
 
 /// \brief Remove PKCS#7 padding from data.
 /// \param data Padded data.
-/// \return Data with padding removed.
-std::vector<uint8_t> remove_padding(const std::vector<uint8_t> &data);
+/// \param out Receives data with padding removed.
+/// \return True if padding is valid.
+bool remove_padding(const std::vector<uint8_t> &data,
+                    std::vector<uint8_t> &out) noexcept;
 
 /// \brief Prepend IV to ciphertext.
 /// \param ciphertext Ciphertext without IV.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -634,6 +634,15 @@ TEST(Utils, EncryptDecryptStringCBC) {
   ASSERT_EQ(text, dec);
 }
 
+TEST(Utils, DecryptStringCbcInvalidPadding) {
+  std::string text = "hello world";
+  std::array<uint8_t, 16> key = {0};
+  auto enc = aescpp::utils::encrypt(text, key, aescpp::utils::AesMode::CBC);
+  enc.ciphertext.back() ^= 0x01;
+  EXPECT_THROW(aescpp::utils::decrypt(enc, key, aescpp::utils::AesMode::CBC),
+               std::runtime_error);
+}
+
 TEST(Utils, EncryptDecryptCtrZeroLength) {
   std::vector<uint8_t> plain;
   std::array<uint8_t, 16> key = {0};


### PR DESCRIPTION
## Summary
- refactor padding removal to return a boolean status
- treat invalid CBC padding as an authentication failure
- cover invalid CBC padding with a unit test

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b79e0e531c832cb5d9e2228e77a0d6