### PR TITLE
refactor: scope debug macro and document helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build_test:
 	docker-compose exec aes g++ $(FLAGS) -g -pthread ./src/aes.cpp ./src/aes_utils.cpp ./tests/tests.cpp /usr/lib/libgtest.a -o bin/test
 
 build_debug:
-	docker-compose exec aes g++ $(FLAGS) -g ./src/aes.cpp ./src/aes_utils.cpp ./dev/main.cpp -o bin/debug
+	docker-compose exec aes g++ $(FLAGS) -g -DAESCPP_DEBUG ./src/aes.cpp ./src/aes_utils.cpp ./dev/main.cpp -o bin/debug
 
 build_profile:
 	docker-compose exec aes g++ $(FLAGS) -pg ./src/aes.cpp ./src/aes_utils.cpp ./dev/main.cpp -o bin/profile

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ AES aesVec(AESKeyLength::AES_128);
 auto cipherVec = aesVec.EncryptCBC(plainVec, keyVec, iv);
 ```
 
+## Debug Helpers
+
+Defining the `AESCPP_DEBUG` macro enables helper functions such as `printHexArray` and `printHexVector` for inspecting data. These helpers are for debugging only and must not be used with sensitive data in production builds. The `make build_debug` target defines this macro automatically, or you can compile with `-DAESCPP_DEBUG`.
+
 ## Usage
 
 ### Encryption/Decryption
@@ -107,7 +111,7 @@ CBC doesn't satisfy this condition an exception will be thrown
 
 There are four executables in `bin` folder:  
 * `test` - run tests  
-* `debug` - version for debugging (main code will be taken from dev/main.cpp)  
+* `debug` - version for debugging built with `AESCPP_DEBUG` (main code will be taken from dev/main.cpp)
 * `profile` - version for profiling with gprof (main code will be taken from dev/main.cpp)  
 * `speedtest` - performance speed test (main code will be taken from speedtest/main.cpp)
 * `release` - version with optimization (main code will be taken from dev/main.cpp)  
@@ -116,7 +120,7 @@ There are four executables in `bin` folder:
 Build commands:  
 * `make build_all` - build all targets
 * `make build_test` - build `test` target
-* `make build_debug` - build `debug` target
+* `make build_debug` - build `debug` target (defines `AESCPP_DEBUG`)
 * `make build_profile` - build `profile` target
 * `make build_speed_test` - build `speedtest` target
 * `make build_release` - build `release` target

--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -448,17 +448,22 @@ class AES {
                   const unsigned char aad[], size_t aadLen,
                   const unsigned char tag[], unsigned char out[]);
 
+#ifdef AESCPP_DEBUG
   /// \brief Print byte array as hexadecimal values.
   /// \param a Array to print.
   /// \param n Number of bytes in \p a.
+  /// \warning For debugging only; do not use with sensitive data in production.
   void printHexArray(unsigned char a[], size_t n);
 
   /// \brief Print vector contents as hexadecimal values.
   /// \param a Vector to print.
+  /// \warning For debugging only; do not use with sensitive data in production.
   void printHexVector(const std::vector<unsigned char> &a);
 
   /// \overload
+  /// \warning For debugging only; do not use with sensitive data in production.
   void printHexVector(std::vector<unsigned char> &&a);
+#endif
 
  private:
   static constexpr unsigned int Nb = 4;

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -1058,6 +1058,8 @@ void AES::XorBlocks(const unsigned char *a, const unsigned char *b,
 #endif
 }
 
+#ifdef AESCPP_DEBUG  // Debug helpers - do not use with sensitive data in
+                     // production
 void AES::printHexArray(unsigned char a[], size_t n) {
   for (size_t i = 0; i < n; i++) {
     printf("%02x ", a[i]);
@@ -1075,6 +1077,7 @@ void AES::printHexVector(std::vector<unsigned char> &&a) {
     printf("%02x ", a[i]);
   }
 }
+#endif
 
 std::vector<unsigned char> AES::ArrayToVector(unsigned char *a, size_t len) {
   std::vector<unsigned char> v(a, a + len);


### PR DESCRIPTION
## Summary
- replace global `DEBUG` flag with project-scoped `AESCPP_DEBUG`
- guard hex dump helpers behind `AESCPP_DEBUG` and document their limitations
- define `AESCPP_DEBUG` for `build_debug` target and document usage in the README

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b79de7b054832cab60088ff3574136