### PR TITLE
fix: defer round key zeroization

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,8 +4,11 @@
 #include <aescpp/aes_utils.hpp>
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <future>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -27,22 +30,35 @@ TEST(Internal, ConstantTimeEq) {
   EXPECT_FALSE(aescpp::constant_time_eq(a, c, sizeof(a)));
 }
 
-TEST(Internal, ReplaceKeyZeroizesOldRoundKeys) {
+TEST(Internal, ConcurrentKeyPreparationDoesNotAffectEncryption) {
   aescpp::AES aes(aescpp::AESKeyLength::AES_128);
-  unsigned char key1[16];
-  for (size_t i = 0; i < sizeof(key1); ++i) {
-    key1[i] = static_cast<unsigned char>(i);
-  }
-  auto oldRoundKeys = aes.prepare_round_keys(key1);
-  ASSERT_TRUE(std::any_of(oldRoundKeys->begin(), oldRoundKeys->end(),
-                          [](unsigned char b) { return b != 0; }));
-  unsigned char key2[16];
-  for (size_t i = 0; i < sizeof(key2); ++i) {
-    key2[i] = static_cast<unsigned char>(i + 1);
-  }
+  unsigned char plain[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                           0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+  unsigned char key1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                          0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+  unsigned char key2[] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                          0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
+  auto roundKeys = aes.prepare_round_keys(key1);
+
+  std::promise<void> ready;
+  std::atomic<bool> go{false};
+  std::array<unsigned char, 16> out;
+
+  std::thread t([&]() {
+    ready.set_value();
+    while (!go.load()) {
+    }
+    aes.EncryptBlock(plain, out.data(), roundKeys->data());
+  });
+
+  ready.get_future().wait();
   aes.prepare_round_keys(key2);
-  EXPECT_TRUE(std::all_of(oldRoundKeys->begin(), oldRoundKeys->end(),
-                          [](unsigned char b) { return b == 0; }));
+  go = true;
+  t.join();
+
+  unsigned char expected[] = {0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30,
+                              0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4, 0xc5, 0x5a};
+  ASSERT_FALSE(memcmp(expected, out.data(), sizeof(expected)));
 }
 
 TEST(KeyLengths, KeyLength128) {


### PR DESCRIPTION
## Summary
- ensure round key memory is zeroized only once the final shared_ptr reference is released
- document custom deleter usage
- add concurrent encryption test to confirm previous key remains valid during key update

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b14a4838832ca4521065b12b7de5