### PR TITLE
feat(core): add key cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ AES aesVec(AESKeyLength::AES_128);
 auto cipherVec = aesVec.EncryptCBC(plainVec, keyVec, iv);
 ```
 
+## Clearing Cached Keys
+The `AES` class caches the last key and its expanded round keys for reuse.
+Call `clear_cache()` when this material is no longer needed to securely erase
+it. The destructor invokes this automatically.
+
 ## Debug Helpers
 
 Defining the `AESCPP_DEBUG` macro enables helper functions such as `printHexArray` and `printHexVector` for inspecting data. These helpers are for debugging only and must not be used with sensitive data in production builds. The `make build_debug` target defines this macro automatically, or you can compile with `-DAESCPP_DEBUG`.

--- a/include/aescpp/aes.hpp
+++ b/include/aescpp/aes.hpp
@@ -64,6 +64,11 @@ class AES {
   /// \brief Destroy the AES object and securely clear cached keys.
   ~AES();
 
+  /// \brief Securely erase cached key material.
+  /// \note Call after sensitive operations to remove residual keys. The
+  ///       destructor invokes this automatically.
+  void clear_cache();
+
   /// \brief Encrypt data using ECB mode.
   /// \warning ECB mode leaks plaintext patterns and should not be used for new
   ///          code. Prefer an authenticated mode like GCM.

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -231,9 +231,13 @@ AES::AES(const AESKeyLength keyLength) {
   }
 }
 
-AES::~AES() {
+AES::~AES() { clear_cache(); }
+
+void AES::clear_cache() {
+  std::unique_lock<AESCPP_SHARED_MUTEX> lock(cacheMutex);
   cachedRoundKeys.reset();
   secure_zero(cachedKey.data(), cachedKey.size());
+  cachedKey.clear();
 }
 
 std::shared_ptr<const std::vector<unsigned char>> AES::prepare_round_keys(


### PR DESCRIPTION
## Summary
- add `clear_cache` to AES for clearing cached key material with thread safety
- document key cache behavior and clearing procedure

## Testing
- `make workflow_build_test`
- `bin/test`
- `pre-commit run --files src/aes.cpp include/aescpp/aes.hpp README.md` *(fails: `.pre-commit-config.yaml is not a file`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c7eba9d8832c94dcaaf1650edb5f