### PR TITLE
fix(utils): make remove_padding constant time

### DIFF
--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -228,10 +228,11 @@ bool remove_padding(const std::vector<uint8_t> &data,
     uint8_t mask = static_cast<uint8_t>(0 - static_cast<uint8_t>(i < padding));
     diff |= (byte ^ padding) & mask;
   }
-  out = data;
   size_t mask = -static_cast<size_t>((invalid | diff) == 0);
   size_t final_len = ((len - padding) & mask) | (len & ~mask);
-  out.resize(final_len);
+  std::vector<uint8_t> tmp = data;
+  tmp.resize(final_len);
+  out.swap(tmp);
   return mask != 0;
 }
 

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -229,11 +229,10 @@ bool remove_padding(const std::vector<uint8_t> &data,
     diff |= (byte ^ padding) & mask;
   }
   out = data;
-  if ((invalid | diff) == 0) {
-    out.resize(len - padding);
-    return true;
-  }
-  return false;
+  size_t mask = -static_cast<size_t>((invalid | diff) == 0);
+  size_t final_len = ((len - padding) & mask) | (len & ~mask);
+  out.resize(final_len);
+  return mask != 0;
 }
 
 std::vector<uint8_t> add_iv_to_ciphertext(

--- a/src/aes_utils.cpp
+++ b/src/aes_utils.cpp
@@ -225,7 +225,7 @@ bool remove_padding(const std::vector<uint8_t> &data,
     if (i < len) {
       byte = data[len - 1 - i];
     }
-    uint8_t mask = static_cast<uint8_t>(i < padding ? 0xFF : 0x00);
+    uint8_t mask = static_cast<uint8_t>(0 - static_cast<uint8_t>(i < padding));
     diff |= (byte ^ padding) & mask;
   }
   out = data;


### PR DESCRIPTION
## Summary
- eliminate data-dependent branch in `remove_padding`
- compute output length with mask arithmetic and resize unconditionally for constant timing

## Testing
- `make workflow_build_test`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf478928832c8643194a18dcd689