### PR TITLE
Silence deprecated warnings in ECB tests

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -14,6 +14,14 @@
 
 #include "gtest/gtest.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 const unsigned int BLOCK_BYTES_LENGTH = 16 * sizeof(unsigned char);
 
 namespace aescpp {
@@ -775,3 +783,9 @@ int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
## Summary
- suppress deprecation warnings for ECB API tests
- restore compiler diagnostics after test suite

## Testing
- `make workflow_build_test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d4e1be78832c91da241773e2f91e