### PR TITLE
build: install targets and generate CMake package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8)
 
 project(aes_cpp CXX)
 
+include(CMakePackageConfigHelpers)
+
+set(AES_CPP_VERSION 0.1.0)
+
 option(AES_CPP_BUILD_TESTS "Build aes_cpp tests" OFF)
 
 set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
@@ -11,7 +15,44 @@ set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_library(aes ${SOURCE_FILES})
 add_library(aes_cpp::aes_cpp ALIAS aes)
 add_library(aescpp ALIAS aes)
-target_include_directories(aes PUBLIC ${INCLUDE_DIR})
+target_include_directories(aes
+  PUBLIC
+    $<BUILD_INTERFACE:${INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+set_target_properties(aes PROPERTIES EXPORT_NAME aes_cpp)
+
+install(TARGETS aes EXPORT aes_cppTargets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include)
+
+install(DIRECTORY include/ DESTINATION include)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/aes_cppConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/aes_cppConfig.cmake
+  INSTALL_DESTINATION lib/cmake/aes_cpp
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/aes_cppConfigVersion.cmake
+  VERSION ${AES_CPP_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/aes_cppConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/aes_cppConfigVersion.cmake
+  DESTINATION lib/cmake/aes_cpp
+)
+
+install(EXPORT aes_cppTargets
+  FILE aes_cppTargets.cmake
+  NAMESPACE aes_cpp::
+  DESTINATION lib/cmake/aes_cpp
+)
 
 if(AES_CPP_BUILD_TESTS)
   add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ add_subdirectory(path/to/aes-cpp)
 target_link_libraries(your_app PRIVATE aes_cpp::aes_cpp)
 ```
 
+Alternatively, install the library and use `find_package`:
+
+```bash
+cmake -S . -B build
+cmake --install build --prefix /your/install/prefix
+```
+
+```cmake
+find_package(aes_cpp CONFIG REQUIRED)
+target_link_libraries(your_app PRIVATE aes_cpp::aes_cpp)
+```
+
 ## Hardware Acceleration
 On x86 CPUs this library checks for AES-NI support at runtime and uses
 hardware-accelerated instructions when available. If AES-NI is missing, a

--- a/cmake/aes_cppConfig.cmake.in
+++ b/cmake/aes_cppConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/aes_cppTargets.cmake")
+
+check_required_components(aes_cpp)


### PR DESCRIPTION
## Summary
- add installation rules and CMake package configuration
- document library installation and `find_package` usage

## Testing
- `cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`
- `cmake --install build --prefix /tmp/aes_install`


------
https://chatgpt.com/codex/tasks/task_e_68b98eb2eb34832c830cc4fa0464f8ab