### PR TITLE
docs(readme): add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # aes-cpp
 
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Building with vcpkg](#building-with-vcpkg)
+- [CMake Integration](#cmake-integration)
+- [Usage](#usage)
+- [Development](#development)
+
 C++ AES(Advanced Encryption Standard) implementation.
 
 Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).


### PR DESCRIPTION
## Summary
- add table of contents linking to major sections in the README for easier navigation

## Testing
- `./setup-hooks.sh`
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` *(fails: gtest/gtest.h: No such file or directory)*
- `./bin/test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7f23fe2c832c85be990c14a8f295