### PR TITLE
fix: guard PCLMUL GHASH with SSSE3 and use memcpy in XorBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ int main() {
 }
 ```
 
-**Note (CTR):** throws on 128-bit counter wrap-around (practically unreachable).
+**Note (CTR):** throws `std::length_error` on 128-bit counter wrap-around (practically unreachable).
 
 ### GCM example (AEAD) + serialization
 
@@ -287,12 +287,13 @@ A span-like API may be added later.
 ## Hardware Acceleration
 
 * **x86/x86_64**: runtime AES-NI detection; hardware path when available, otherwise software fallback.
-* **GHASH** (GCM) uses PCLMULQDQ when available.
+* **GHASH** (GCM) uses PCLMULQDQ with SSSE3 shuffles when available.
 * **Non-x86 (e.g., ARMv8)**: currently uses software path (no ARM Crypto Extensions yet).
 
 ### Build flags for acceleration
-* GCC/Clang: pass `-maes -mpclmul` to compile AES-NI/PCLMUL code paths (selected at runtime).
+* GCC/Clang: pass `-maes -mpclmul -mssse3` to compile AES-NI/PCLMUL code paths (selected at runtime).
 * MSVC: intrinsics available by default; CPUID selects the path at runtime.
+* Without these flags, the software path is always used.
 
 ## Windows Build
 


### PR DESCRIPTION
## Summary
- require SSSE3 for the PCLMUL GHASH path
- replace unaligned uint64_t XOR with memcpy and drop macro
- document acceleration flags and runtime limits

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68bb058a7344832caf5811fb57c36e57