### PR TITLE
ci: update checkout action to v4

### DIFF
--- a/.github/workflows/aes-ci.yml
+++ b/.github/workflows/aes-ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         std: [11, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Code style (check only)
         run: |
@@ -59,7 +59,7 @@ jobs:
   vcpkg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg.git
@@ -75,7 +75,7 @@ jobs:
   sanitizers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build gtest
         run: |
           sudo apt-get update
@@ -97,7 +97,7 @@ jobs:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build and test
         run: |
           cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- use actions/checkout@v4 in aes-ci workflow

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68bf22ed0d4c832ca3b51bd54317ef7a